### PR TITLE
add BR0009 and BR0010, no descriptions

### DIFF
--- a/Brazil/BR_Data_Guide.csv
+++ b/Brazil/BR_Data_Guide.csv
@@ -7,3 +7,5 @@ BR0005,microcephaly_fatal_under_investigation,Classification of suspect cases of
 BR0006,microcephaly_fatal_confirmed,Classification of suspect cases of microcephaly and/or altered central nervous system who died after birth or during pregnancy - Confirmed,Classifica??o dos casos notificados com microcefalia e/ou altera??o do SNC que evolu?ram para ?bito ap?s o parto ou durante a gesta??o - Confirmado,COES_Microcephaly,cases,NA
 BR0007,microcephaly_fatal_not,Classification of suspect cases of microcephaly and/or altered central nervous system who died after birth or during pregnancy - Discarded,Classifica??o dos casos notificados com microcefalia e/ou altera??o do SNC que evolu?ram para ?bito ap?s o parto ou durante a gesta??o - Descartado,COES_Microcephaly,cases,NA
 BR0008,municipality_microcephaly_suspected,Number of municipalities with suspected microcephaly cases,Total de munic?pios com casos notificados,COES_Microcephaly,municipalities,NA
+BR0009,microcephaly_confirmed_infection_signs
+BR0010,microcephaly_confirmed_zikv_positive


### PR DESCRIPTION
from @majohansson's suggestions in #2 

added

```
BR0009,microcephaly_confirmed_infection_signs
BR0010,microcephaly_confirmed_zikv_positive
```

to the data guide, but the rest of the rows in the data guide are empty...
