### PR TITLE
Add reference to nextstrain zika phylogeny

### DIFF
--- a/additional_data.md
+++ b/additional_data.md
@@ -23,6 +23,8 @@
 
 [Uniprot](http://www.uniprot.org/uniprot/?query=Zika+virus+&sort=score) - unreviewed protein data
 
+[nextstrain](http://nextstrain.org/zika/) - virus phylogeny
+
 ### Aggregate news and data
 [Models of Infectious Disease Agent Study](http://dujour.obc.io/#/?title=Zika%20Information&class-uri=http:%2F%2Fwww.pitt.edu%2Fobc%2FIDE_0000000014&recent-threshold=30) - various Zika-related reports
 


### PR DESCRIPTION
Add link to [nextstrain.org/zika](http://nextstrain.org/zika/) to the Additional Data page.
