### PR TITLE
"data_field_type" should be "data_field_code"

### DIFF
--- a/Colombia/Municipality_Zika/data/Municipality_Zika_2016-02-27.csv
+++ b/Colombia/Municipality_Zika/data/Municipality_Zika_2016-02-27.csv
@@ -1,4 +1,4 @@
-"report_date","location","location_type","data_field","data_field_type","time_period","time_period_type","value","unit"
+"report_date","location","location_type","data_field","data_field_code","time_period","time_period_type","value","unit"
 2016-02-27,"Colombia-Antioquia-Unknown","municipality","zika_confirmed_laboratory","CO0001",NA,NA,3,"cases"
 2016-02-27,"Colombia-Antioquia-Medellin","municipality","zika_confirmed_laboratory","CO0001",NA,NA,44,"cases"
 2016-02-27,"Colombia-Antioquia-Abejorral","municipality","zika_confirmed_laboratory","CO0001",NA,NA,0,"cases"

--- a/Colombia/Municipality_Zika/data/Municipality_Zika_2016-03-05.csv
+++ b/Colombia/Municipality_Zika/data/Municipality_Zika_2016-03-05.csv
@@ -1,4 +1,4 @@
-"report_date","location","location_type","data_field","data_field_type","time_period","time_period_type","value","unit"
+"report_date","location","location_type","data_field","data_field_code","time_period","time_period_type","value","unit"
 2016-03-05,"Colombia-Antioquia-Unknown","municipality","zika_confirmed_laboratory","CO0001",NA,NA,3,"cases"
 2016-03-05,"Colombia-Antioquia-Medellin","municipality","zika_confirmed_laboratory","CO0001",NA,NA,44,"cases"
 2016-03-05,"Colombia-Antioquia-Abejorral","municipality","zika_confirmed_laboratory","CO0001",NA,NA,0,"cases"

--- a/Colombia/Municipality_Zika/data/Municipality_Zika_2016-03-12.csv
+++ b/Colombia/Municipality_Zika/data/Municipality_Zika_2016-03-12.csv
@@ -1,4 +1,4 @@
-"report_date","location","location_type","data_field","data_field_type","time_period","time_period_type","value","unit"
+"report_date","location","location_type","data_field","data_field_code","time_period","time_period_type","value","unit"
 2016-03-12,"Colombia-Antioquia-Unknown","municipality","zika_confirmed_laboratory","CO0001",NA,NA,3,"cases"
 2016-03-12,"Colombia-Antioquia-Medellin","municipality","zika_confirmed_laboratory","CO0001",NA,NA,44,"cases"
 2016-03-12,"Colombia-Antioquia-Abejorral","municipality","zika_confirmed_laboratory","CO0001",NA,NA,0,"cases"

--- a/Colombia/Municipality_Zika/data/Municipality_Zika_2016-03-19.csv
+++ b/Colombia/Municipality_Zika/data/Municipality_Zika_2016-03-19.csv
@@ -1,4 +1,4 @@
-"report_date","location","location_type","data_field","data_field_type","time_period","time_period_type","value","unit"
+"report_date","location","location_type","data_field","data_field_code","time_period","time_period_type","value","unit"
 2016-03-19,"Colombia-Antioquia-Unknown","municipality","zika_confirmed_laboratory","CO0001",NA,NA,3,"cases"
 2016-03-19,"Colombia-Antioquia-Medellin","municipality","zika_confirmed_laboratory","CO0001",NA,NA,44,"cases"
 2016-03-19,"Colombia-Antioquia-Abejorral","municipality","zika_confirmed_laboratory","CO0001",NA,NA,0,"cases"

--- a/Colombia/Municipality_Zika/data/Municipality_Zika_2016-03-26.csv
+++ b/Colombia/Municipality_Zika/data/Municipality_Zika_2016-03-26.csv
@@ -1,4 +1,4 @@
-"report_date","location","location_type","data_field","data_field_type","time_period","time_period_type","value","unit"
+"report_date","location","location_type","data_field","data_field_code","time_period","time_period_type","value","unit"
 2016-03-26,"Colombia-Antioquia-Unknown","municipality","zika_confirmed_laboratory","CO0001",NA,NA,3,"cases"
 2016-03-26,"Colombia-Antioquia-Medellin","municipality","zika_confirmed_laboratory","CO0001",NA,NA,45,"cases"
 2016-03-26,"Colombia-Antioquia-Abejorral","municipality","zika_confirmed_laboratory","CO0001",NA,NA,0,"cases"

--- a/Colombia/Municipality_Zika/data/Municipality_Zika_2016-04-02.csv
+++ b/Colombia/Municipality_Zika/data/Municipality_Zika_2016-04-02.csv
@@ -1,4 +1,4 @@
-"report_date","location","location_type","data_field","data_field_type","time_period","time_period_type","value","unit"
+"report_date","location","location_type","data_field","data_field_code","time_period","time_period_type","value","unit"
 2016-04-02,"Colombia-Antioquia-Unknown","municipality","zika_confirmed_laboratory","CO0001",NA,NA,3,"cases"
 2016-04-02,"Colombia-Antioquia-Medellin","municipality","zika_confirmed_laboratory","CO0001",NA,NA,49,"cases"
 2016-04-02,"Colombia-Antioquia-Abejorral","municipality","zika_confirmed_laboratory","CO0001",NA,NA,0,"cases"


### PR DESCRIPTION
problem was noticed when I tried to stack all the data in the repo

``` R
files <- list.files(path = sprintf('data/zika-%s', cdc_data_commit),
                    pattern = '[0-9]{4}-[0-9]{2}-[0-9]{2}.csv$',
                    recursive = TRUE,
                    full.names = TRUE)

tables <- lapply(files, readr::read_csv)

combined_df <- do.call(rbind , tables)
```

This gave the following errror

``` R
Error in match.names(clabs, names(xi)) : 
  names do not match previous names
```

All the csv files were recognized, but the data was not being rbinded.

Upon further investivation, it seemed that the data was not able to `rbind` because the column names were different

``` R
m <- sapply(X = tables, FUN = names)
apply(X = m, MARGIN = 1, FUN = function(x){length(unique(x)) == 1})
```

returned

``` R
[1]  TRUE  TRUE  TRUE  TRUE FALSE  TRUE  TRUE  TRUE  TRUE
```

There were inconsistencies in the 5th column name, it had 2 different unique values:

``` R
apply(X = m, MARGIN = 1, FUN = function(x){length(unique(x))})
[1] 1 1 1 1 2 1 1 1 1
```

to see which files they were:

``` R
files[!m[5, ] == "data_field_code"]
[1] "data/zika-3802d3ad29ba28472ce89896e274c97e6b79b58c/Colombia/Municipality_Zika/data/Municipality_Zika_2016-02-27.csv"
[2] "data/zika-3802d3ad29ba28472ce89896e274c97e6b79b58c/Colombia/Municipality_Zika/data/Municipality_Zika_2016-03-05.csv"
[3] "data/zika-3802d3ad29ba28472ce89896e274c97e6b79b58c/Colombia/Municipality_Zika/data/Municipality_Zika_2016-03-12.csv"
[4] "data/zika-3802d3ad29ba28472ce89896e274c97e6b79b58c/Colombia/Municipality_Zika/data/Municipality_Zika_2016-03-19.csv"
[5] "data/zika-3802d3ad29ba28472ce89896e274c97e6b79b58c/Colombia/Municipality_Zika/data/Municipality_Zika_2016-03-26.csv"
[6] "data/zika-3802d3ad29ba28472ce89896e274c97e6b79b58c/Colombia/Municipality_Zika/data/Municipality_Zika_2016-04-02.csv"
```
