### PR TITLE
Adding sivigila code to Colombia places table

### DIFF
--- a/Colombia/CO_Places.csv
+++ b/Colombia/CO_Places.csv
@@ -1,1224 +1,1224 @@
-location,location_type,country,state_province,district_county_municipality,city,alt_name1,alt_name2
-Colombia-Antioquia-Unknown,municipality,Colombia,Antioquia,Unknown,NA,ANTIOQUIA,* ANTIOQUIA. MUNICIPIO DESCONOCIDO
-Colombia-Antioquia-Medellin,municipality,Colombia,Antioquia,Medellin,NA,ANTIOQUIA,MEDELLIN
-Colombia-Antioquia-Abejorral,municipality,Colombia,Antioquia,Abejorral,NA,ANTIOQUIA,ABEJORRAL
-Colombia-Antioquia-Abriaqui,municipality,Colombia,Antioquia,Abriaqui,NA,ANTIOQUIA,ABRIAQUI
-Colombia-Antioquia-Alejandria,municipality,Colombia,Antioquia,Alejandria,NA,ANTIOQUIA,ALEJANDRIA
-Colombia-Antioquia-Amaga,municipality,Colombia,Antioquia,Amaga,NA,ANTIOQUIA,AMAGA
-Colombia-Antioquia-Amalfi,municipality,Colombia,Antioquia,Amalfi,NA,ANTIOQUIA,AMALFI
-Colombia-Antioquia-Andes,municipality,Colombia,Antioquia,Andes,NA,ANTIOQUIA,ANDES
-Colombia-Antioquia-Angelopolis,municipality,Colombia,Antioquia,Angelopolis,NA,ANTIOQUIA,ANGELOPOLIS
-Colombia-Antioquia-Angostura,municipality,Colombia,Antioquia,Angostura,NA,ANTIOQUIA,ANGOSTURA
-Colombia-Antioquia-Anori,municipality,Colombia,Antioquia,Anori,NA,ANTIOQUIA,ANORI
-Colombia-Antioquia-Santafe_De_Antioquia,municipality,Colombia,Antioquia,Santafe_De_Antioquia,NA,ANTIOQUIA,SANTAFE DE ANTIOQUIA
-Colombia-Antioquia-Anza,municipality,Colombia,Antioquia,Anza,NA,ANTIOQUIA,ANZA
-Colombia-Antioquia-Apartado,municipality,Colombia,Antioquia,Apartado,NA,ANTIOQUIA,APARTADO
-Colombia-Antioquia-Arboletes,municipality,Colombia,Antioquia,Arboletes,NA,ANTIOQUIA,ARBOLETES
-Colombia-Antioquia-Argelia,municipality,Colombia,Antioquia,Argelia,NA,ANTIOQUIA,ARGELIA
-Colombia-Antioquia-Armenia,municipality,Colombia,Antioquia,Armenia,NA,ANTIOQUIA,ARMENIA
-Colombia-Antioquia-Barbosa,municipality,Colombia,Antioquia,Barbosa,NA,ANTIOQUIA,BARBOSA
-Colombia-Antioquia-Belmira,municipality,Colombia,Antioquia,Belmira,NA,ANTIOQUIA,BELMIRA
-Colombia-Antioquia-Bello,municipality,Colombia,Antioquia,Bello,NA,ANTIOQUIA,BELLO
-Colombia-Antioquia-Betania,municipality,Colombia,Antioquia,Betania,NA,ANTIOQUIA,BETANIA
-Colombia-Antioquia-Betulia,municipality,Colombia,Antioquia,Betulia,NA,ANTIOQUIA,BETULIA
-Colombia-Antioquia-Ciudad_Bolivar,municipality,Colombia,Antioquia,Ciudad_Bolivar,NA,ANTIOQUIA,CIUDAD BOLIVAR
-Colombia-Antioquia-Briceno,municipality,Colombia,Antioquia,Briceno,NA,ANTIOQUIA,BRICEÑO
-Colombia-Antioquia-Buritica,municipality,Colombia,Antioquia,Buritica,NA,ANTIOQUIA,BURITICA
-Colombia-Antioquia-Caceres,municipality,Colombia,Antioquia,Caceres,NA,ANTIOQUIA,CACERES
-Colombia-Antioquia-Caicedo,municipality,Colombia,Antioquia,Caicedo,NA,ANTIOQUIA,CAICEDO
-Colombia-Antioquia-Caldas,municipality,Colombia,Antioquia,Caldas,NA,ANTIOQUIA,CALDAS
-Colombia-Antioquia-Campamento,municipality,Colombia,Antioquia,Campamento,NA,ANTIOQUIA,CAMPAMENTO
-Colombia-Antioquia-Canasgordas,municipality,Colombia,Antioquia,Canasgordas,NA,ANTIOQUIA,CAÑASGORDAS
-Colombia-Antioquia-Caracoli,municipality,Colombia,Antioquia,Caracoli,NA,ANTIOQUIA,CARACOLI
-Colombia-Antioquia-Caramanta,municipality,Colombia,Antioquia,Caramanta,NA,ANTIOQUIA,CARAMANTA
-Colombia-Antioquia-Carepa,municipality,Colombia,Antioquia,Carepa,NA,ANTIOQUIA,CAREPA
-Colombia-Antioquia-El_Carmen_De_Viboral,municipality,Colombia,Antioquia,El_Carmen_De_Viboral,NA,ANTIOQUIA,EL CARMEN DE VIBORAL
-Colombia-Antioquia-Carolina,municipality,Colombia,Antioquia,Carolina,NA,ANTIOQUIA,CAROLINA
-Colombia-Antioquia-Caucasia,municipality,Colombia,Antioquia,Caucasia,NA,ANTIOQUIA,CAUCASIA
-Colombia-Antioquia-Chigorodo,municipality,Colombia,Antioquia,Chigorodo,NA,ANTIOQUIA,CHIGORODO
-Colombia-Antioquia-Cisneros,municipality,Colombia,Antioquia,Cisneros,NA,ANTIOQUIA,CISNEROS
-Colombia-Antioquia-Cocorna,municipality,Colombia,Antioquia,Cocorna,NA,ANTIOQUIA,COCORNA
-Colombia-Antioquia-Concepcion,municipality,Colombia,Antioquia,Concepcion,NA,ANTIOQUIA,CONCEPCION
-Colombia-Antioquia-Concordia,municipality,Colombia,Antioquia,Concordia,NA,ANTIOQUIA,CONCORDIA
-Colombia-Antioquia-Copacabana,municipality,Colombia,Antioquia,Copacabana,NA,ANTIOQUIA,COPACABANA
-Colombia-Antioquia-Dabeiba,municipality,Colombia,Antioquia,Dabeiba,NA,ANTIOQUIA,DABEIBA
-Colombia-Antioquia-Don_Matias,municipality,Colombia,Antioquia,Don_Matias,NA,ANTIOQUIA,DON MATIAS
-Colombia-Antioquia-Ebejico,municipality,Colombia,Antioquia,Ebejico,NA,ANTIOQUIA,EBEJICO
-Colombia-Antioquia-El_Bagre,municipality,Colombia,Antioquia,El_Bagre,NA,ANTIOQUIA,EL BAGRE
-Colombia-Antioquia-Entrerrios,municipality,Colombia,Antioquia,Entrerrios,NA,ANTIOQUIA,ENTRERRIOS
-Colombia-Antioquia-Envigado,municipality,Colombia,Antioquia,Envigado,NA,ANTIOQUIA,ENVIGADO
-Colombia-Antioquia-Fredonia,municipality,Colombia,Antioquia,Fredonia,NA,ANTIOQUIA,FREDONIA
-Colombia-Antioquia-Frontino,municipality,Colombia,Antioquia,Frontino,NA,ANTIOQUIA,FRONTINO
-Colombia-Antioquia-Giraldo,municipality,Colombia,Antioquia,Giraldo,NA,ANTIOQUIA,GIRALDO
-Colombia-Antioquia-Girardota,municipality,Colombia,Antioquia,Girardota,NA,ANTIOQUIA,GIRARDOTA
-Colombia-Antioquia-Gomez_Plata,municipality,Colombia,Antioquia,Gomez_Plata,NA,ANTIOQUIA,GOMEZ PLATA
-Colombia-Antioquia-Granada,municipality,Colombia,Antioquia,Granada,NA,ANTIOQUIA,GRANADA
-Colombia-Antioquia-Guadalupe,municipality,Colombia,Antioquia,Guadalupe,NA,ANTIOQUIA,GUADALUPE
-Colombia-Antioquia-Guarne,municipality,Colombia,Antioquia,Guarne,NA,ANTIOQUIA,GUARNE
-Colombia-Antioquia-Guatape,municipality,Colombia,Antioquia,Guatape,NA,ANTIOQUIA,GUATAPE
-Colombia-Antioquia-Heliconia,municipality,Colombia,Antioquia,Heliconia,NA,ANTIOQUIA,HELICONIA
-Colombia-Antioquia-Hispania,municipality,Colombia,Antioquia,Hispania,NA,ANTIOQUIA,HISPANIA
-Colombia-Antioquia-Itagui,municipality,Colombia,Antioquia,Itagui,NA,ANTIOQUIA,ITAGUI
-Colombia-Antioquia-Ituango,municipality,Colombia,Antioquia,Ituango,NA,ANTIOQUIA,ITUANGO
-Colombia-Antioquia-Jardin,municipality,Colombia,Antioquia,Jardin,NA,ANTIOQUIA,JARDIN
-Colombia-Antioquia-Jerico,municipality,Colombia,Antioquia,Jerico,NA,ANTIOQUIA,JERICO
-Colombia-Antioquia-La_Ceja,municipality,Colombia,Antioquia,La_Ceja,NA,ANTIOQUIA,LA CEJA
-Colombia-Antioquia-La_Estrella,municipality,Colombia,Antioquia,La_Estrella,NA,ANTIOQUIA,LA ESTRELLA
-Colombia-Antioquia-La_Pintada,municipality,Colombia,Antioquia,La_Pintada,NA,ANTIOQUIA,LA PINTADA
-Colombia-Antioquia-La_Union,municipality,Colombia,Antioquia,La_Union,NA,ANTIOQUIA,LA UNION
-Colombia-Antioquia-Liborina,municipality,Colombia,Antioquia,Liborina,NA,ANTIOQUIA,LIBORINA
-Colombia-Antioquia-Maceo,municipality,Colombia,Antioquia,Maceo,NA,ANTIOQUIA,MACEO
-Colombia-Antioquia-Marinilla,municipality,Colombia,Antioquia,Marinilla,NA,ANTIOQUIA,MARINILLA
-Colombia-Antioquia-Montebello,municipality,Colombia,Antioquia,Montebello,NA,ANTIOQUIA,MONTEBELLO
-Colombia-Antioquia-Murindo,municipality,Colombia,Antioquia,Murindo,NA,ANTIOQUIA,MURINDO
-Colombia-Antioquia-Mutata,municipality,Colombia,Antioquia,Mutata,NA,ANTIOQUIA,MUTATA
-Colombia-Antioquia-Narino,municipality,Colombia,Antioquia,Narino,NA,ANTIOQUIA,NARIÑO
-Colombia-Antioquia-Necocli,municipality,Colombia,Antioquia,Necocli,NA,ANTIOQUIA,NECOCLI
-Colombia-Antioquia-Nechi,municipality,Colombia,Antioquia,Nechi,NA,ANTIOQUIA,NECHI
-Colombia-Antioquia-Olaya,municipality,Colombia,Antioquia,Olaya,NA,ANTIOQUIA,OLAYA
-Colombia-Antioquia-Peðol,municipality,Colombia,Antioquia,Peðol,NA,ANTIOQUIA,PEÐOL
-Colombia-Antioquia-Peque,municipality,Colombia,Antioquia,Peque,NA,ANTIOQUIA,PEQUE
-Colombia-Antioquia-Pueblorrico,municipality,Colombia,Antioquia,Pueblorrico,NA,ANTIOQUIA,PUEBLORRICO
-Colombia-Antioquia-Puerto_Berrio,municipality,Colombia,Antioquia,Puerto_Berrio,NA,ANTIOQUIA,PUERTO BERRIO
-Colombia-Antioquia-Puerto_Nare,municipality,Colombia,Antioquia,Puerto_Nare,NA,ANTIOQUIA,PUERTO NARE
-Colombia-Antioquia-Puerto_Triunfo,municipality,Colombia,Antioquia,Puerto_Triunfo,NA,ANTIOQUIA,PUERTO TRIUNFO
-Colombia-Antioquia-Remedios,municipality,Colombia,Antioquia,Remedios,NA,ANTIOQUIA,REMEDIOS
-Colombia-Antioquia-Retiro,municipality,Colombia,Antioquia,Retiro,NA,ANTIOQUIA,RETIRO
-Colombia-Antioquia-Rionegro,municipality,Colombia,Antioquia,Rionegro,NA,ANTIOQUIA,RIONEGRO
-Colombia-Antioquia-Sabanalarga,municipality,Colombia,Antioquia,Sabanalarga,NA,ANTIOQUIA,SABANALARGA
-Colombia-Antioquia-Sabaneta,municipality,Colombia,Antioquia,Sabaneta,NA,ANTIOQUIA,SABANETA
-Colombia-Antioquia-Salgar,municipality,Colombia,Antioquia,Salgar,NA,ANTIOQUIA,SALGAR
-Colombia-Antioquia-San_Andres_De_Cuerquia,municipality,Colombia,Antioquia,San_Andres_De_Cuerquia,NA,ANTIOQUIA,SAN ANDRES DE CUERQUIA
-Colombia-Antioquia-San_Carlos,municipality,Colombia,Antioquia,San_Carlos,NA,ANTIOQUIA,SAN CARLOS
-Colombia-Antioquia-San_Francisco,municipality,Colombia,Antioquia,San_Francisco,NA,ANTIOQUIA,SAN FRANCISCO
-Colombia-Antioquia-San_Jeronimo,municipality,Colombia,Antioquia,San_Jeronimo,NA,ANTIOQUIA,SAN JERONIMO
-Colombia-Antioquia-San_Jose_De_La_Montana,municipality,Colombia,Antioquia,San_Jose_De_La_Montana,NA,ANTIOQUIA,SAN JOSE DE LA MONTAÑA
-Colombia-Antioquia-San_Juan_De_Uraba,municipality,Colombia,Antioquia,San_Juan_De_Uraba,NA,ANTIOQUIA,SAN JUAN DE URABA
-Colombia-Antioquia-San_Luis,municipality,Colombia,Antioquia,San_Luis,NA,ANTIOQUIA,SAN LUIS
-Colombia-Antioquia-San_Pedro,municipality,Colombia,Antioquia,San_Pedro,NA,ANTIOQUIA,SAN PEDRO
-Colombia-Antioquia-San_Pedro_De_Uraba,municipality,Colombia,Antioquia,San_Pedro_De_Uraba,NA,ANTIOQUIA,SAN PEDRO DE URABA
-Colombia-Antioquia-San_Rafael,municipality,Colombia,Antioquia,San_Rafael,NA,ANTIOQUIA,SAN RAFAEL
-Colombia-Antioquia-San_Roque,municipality,Colombia,Antioquia,San_Roque,NA,ANTIOQUIA,SAN ROQUE
-Colombia-Antioquia-San_Vicente,municipality,Colombia,Antioquia,San_Vicente,NA,ANTIOQUIA,SAN VICENTE
-Colombia-Antioquia-Santa_Barbara,municipality,Colombia,Antioquia,Santa_Barbara,NA,ANTIOQUIA,SANTA BARBARA
-Colombia-Antioquia-Santa_Rosa_De_Osos,municipality,Colombia,Antioquia,Santa_Rosa_De_Osos,NA,ANTIOQUIA,SANTA ROSA DE OSOS
-Colombia-Antioquia-Santo_Domingo,municipality,Colombia,Antioquia,Santo_Domingo,NA,ANTIOQUIA,SANTO DOMINGO
-Colombia-Antioquia-El_Santuario,municipality,Colombia,Antioquia,El_Santuario,NA,ANTIOQUIA,EL SANTUARIO
-Colombia-Antioquia-Segovia,municipality,Colombia,Antioquia,Segovia,NA,ANTIOQUIA,SEGOVIA
-Colombia-Antioquia-Sonson,municipality,Colombia,Antioquia,Sonson,NA,ANTIOQUIA,SONSON
-Colombia-Antioquia-Sopetran,municipality,Colombia,Antioquia,Sopetran,NA,ANTIOQUIA,SOPETRAN
-Colombia-Antioquia-Tamesis,municipality,Colombia,Antioquia,Tamesis,NA,ANTIOQUIA,TAMESIS
-Colombia-Antioquia-Taraza,municipality,Colombia,Antioquia,Taraza,NA,ANTIOQUIA,TARAZA
-Colombia-Antioquia-Tarso,municipality,Colombia,Antioquia,Tarso,NA,ANTIOQUIA,TARSO
-Colombia-Antioquia-Titiribi,municipality,Colombia,Antioquia,Titiribi,NA,ANTIOQUIA,TITIRIBI
-Colombia-Antioquia-Toledo,municipality,Colombia,Antioquia,Toledo,NA,ANTIOQUIA,TOLEDO
-Colombia-Antioquia-Turbo,municipality,Colombia,Antioquia,Turbo,NA,ANTIOQUIA,TURBO
-Colombia-Antioquia-Uramita,municipality,Colombia,Antioquia,Uramita,NA,ANTIOQUIA,URAMITA
-Colombia-Antioquia-Urrao,municipality,Colombia,Antioquia,Urrao,NA,ANTIOQUIA,URRAO
-Colombia-Antioquia-Valdivia,municipality,Colombia,Antioquia,Valdivia,NA,ANTIOQUIA,VALDIVIA
-Colombia-Antioquia-Valparaiso,municipality,Colombia,Antioquia,Valparaiso,NA,ANTIOQUIA,VALPARAISO
-Colombia-Antioquia-Vegachi,municipality,Colombia,Antioquia,Vegachi,NA,ANTIOQUIA,VEGACHI
-Colombia-Antioquia-Venecia,municipality,Colombia,Antioquia,Venecia,NA,ANTIOQUIA,VENECIA
-Colombia-Antioquia-Vigia_Del_Fuerte,municipality,Colombia,Antioquia,Vigia_Del_Fuerte,NA,ANTIOQUIA,VIGIA DEL FUERTE
-Colombia-Antioquia-Yali,municipality,Colombia,Antioquia,Yali,NA,ANTIOQUIA,YALI
-Colombia-Antioquia-Yarumal,municipality,Colombia,Antioquia,Yarumal,NA,ANTIOQUIA,YARUMAL
-Colombia-Antioquia-Yolombo,municipality,Colombia,Antioquia,Yolombo,NA,ANTIOQUIA,YOLOMBO
-Colombia-Antioquia-Yondo,municipality,Colombia,Antioquia,Yondo,NA,ANTIOQUIA,YONDO
-Colombia-Antioquia-Zaragoza,municipality,Colombia,Antioquia,Zaragoza,NA,ANTIOQUIA,ZARAGOZA
-Colombia-Barranquilla-Barranquilla,municipality,Colombia,Barranquilla,Barranquilla,NA,BARRANQUILLA,BARRANQUILLA
-Colombia-Atlantico-Unknown,municipality,Colombia,Atlantico,Unknown,NA,ATLANTICO,* ATLANTICO. MUNICIPIO DESCONOCIDO
-Colombia-Atlantico-Baranoa,municipality,Colombia,Atlantico,Baranoa,NA,ATLANTICO,BARANOA
-Colombia-Atlantico-Campo_De_La_Cruz,municipality,Colombia,Atlantico,Campo_De_La_Cruz,NA,ATLANTICO,CAMPO DE LA CRUZ
-Colombia-Atlantico-Candelaria,municipality,Colombia,Atlantico,Candelaria,NA,ATLANTICO,CANDELARIA
-Colombia-Atlantico-Galapa,municipality,Colombia,Atlantico,Galapa,NA,ATLANTICO,GALAPA
-Colombia-Atlantico-Juan_De_Acosta,municipality,Colombia,Atlantico,Juan_De_Acosta,NA,ATLANTICO,JUAN DE ACOSTA
-Colombia-Atlantico-Luruaco,municipality,Colombia,Atlantico,Luruaco,NA,ATLANTICO,LURUACO
-Colombia-Atlantico-Malambo,municipality,Colombia,Atlantico,Malambo,NA,ATLANTICO,MALAMBO
-Colombia-Atlantico-Manati,municipality,Colombia,Atlantico,Manati,NA,ATLANTICO,MANATI
-Colombia-Atlantico-Palmar_De_Varela,municipality,Colombia,Atlantico,Palmar_De_Varela,NA,ATLANTICO,PALMAR DE VARELA
-Colombia-Atlantico-Piojo,municipality,Colombia,Atlantico,Piojo,NA,ATLANTICO,PIOJO
-Colombia-Atlantico-Polonuevo,municipality,Colombia,Atlantico,Polonuevo,NA,ATLANTICO,POLONUEVO
-Colombia-Atlantico-Ponedera,municipality,Colombia,Atlantico,Ponedera,NA,ATLANTICO,PONEDERA
-Colombia-Atlantico-Puerto_Colombia,municipality,Colombia,Atlantico,Puerto_Colombia,NA,ATLANTICO,PUERTO COLOMBIA
-Colombia-Atlantico-Repelon,municipality,Colombia,Atlantico,Repelon,NA,ATLANTICO,REPELON
-Colombia-Atlantico-Sabanagrande,municipality,Colombia,Atlantico,Sabanagrande,NA,ATLANTICO,SABANAGRANDE
-Colombia-Atlantico-Sabanalarga,municipality,Colombia,Atlantico,Sabanalarga,NA,ATLANTICO,SABANALARGA
-Colombia-Atlantico-Santa_Lucia,municipality,Colombia,Atlantico,Santa_Lucia,NA,ATLANTICO,SANTA LUCIA
-Colombia-Atlantico-Santo_Tomas,municipality,Colombia,Atlantico,Santo_Tomas,NA,ATLANTICO,SANTO TOMAS
-Colombia-Atlantico-Soledad,municipality,Colombia,Atlantico,Soledad,NA,ATLANTICO,SOLEDAD
-Colombia-Atlantico-Suan,municipality,Colombia,Atlantico,Suan,NA,ATLANTICO,SUAN
-Colombia-Atlantico-Tubara,municipality,Colombia,Atlantico,Tubara,NA,ATLANTICO,TUBARA
-Colombia-Atlantico-Usiacuri,municipality,Colombia,Atlantico,Usiacuri,NA,ATLANTICO,USIACURI
-Colombia-Cartagena-Cartagena,municipality,Colombia,Cartagena,Cartagena,NA,CARTAGENA,CARTAGENA
-Colombia-Bolivar-Unknown,municipality,Colombia,Bolivar,Unknown,NA,BOLIVAR,* BOLIVAR. MUNICIPIO DESCONOCIDO
-Colombia-Bolivar-Achi,municipality,Colombia,Bolivar,Achi,NA,BOLIVAR,ACHI
-Colombia-Bolivar-Altos_Del_Rosario,municipality,Colombia,Bolivar,Altos_Del_Rosario,NA,BOLIVAR,ALTOS DEL ROSARIO
-Colombia-Bolivar-Arenal,municipality,Colombia,Bolivar,Arenal,NA,BOLIVAR,ARENAL
-Colombia-Bolivar-Arjona,municipality,Colombia,Bolivar,Arjona,NA,BOLIVAR,ARJONA
-Colombia-Bolivar-Arroyohondo,municipality,Colombia,Bolivar,Arroyohondo,NA,BOLIVAR,ARROYOHONDO
-Colombia-Bolivar-Barranco_De_Loba,municipality,Colombia,Bolivar,Barranco_De_Loba,NA,BOLIVAR,BARRANCO DE LOBA
-Colombia-Bolivar-Calamar,municipality,Colombia,Bolivar,Calamar,NA,BOLIVAR,CALAMAR
-Colombia-Bolivar-Cantagallo,municipality,Colombia,Bolivar,Cantagallo,NA,BOLIVAR,CANTAGALLO
-Colombia-Bolivar-Cicuco,municipality,Colombia,Bolivar,Cicuco,NA,BOLIVAR,CICUCO
-Colombia-Bolivar-Cordoba,municipality,Colombia,Bolivar,Cordoba,NA,BOLIVAR,CORDOBA
-Colombia-Bolivar-Clemencia,municipality,Colombia,Bolivar,Clemencia,NA,BOLIVAR,CLEMENCIA
-Colombia-Bolivar-El_Carmen_De_Bolivar,municipality,Colombia,Bolivar,El_Carmen_De_Bolivar,NA,BOLIVAR,EL CARMEN DE BOLIVAR
-Colombia-Bolivar-El_Guamo,municipality,Colombia,Bolivar,El_Guamo,NA,BOLIVAR,EL GUAMO
-Colombia-Bolivar-El_Penon,municipality,Colombia,Bolivar,El_Penon,NA,BOLIVAR,EL PEÑON
-Colombia-Bolivar-Hatillo_De_Loba,municipality,Colombia,Bolivar,Hatillo_De_Loba,NA,BOLIVAR,HATILLO DE LOBA
-Colombia-Bolivar-Magangue,municipality,Colombia,Bolivar,Magangue,NA,BOLIVAR,MAGANGUE
-Colombia-Bolivar-Mahates,municipality,Colombia,Bolivar,Mahates,NA,BOLIVAR,MAHATES
-Colombia-Bolivar-Margarita,municipality,Colombia,Bolivar,Margarita,NA,BOLIVAR,MARGARITA
-Colombia-Bolivar-Maria_La_Baja,municipality,Colombia,Bolivar,Maria_La_Baja,NA,BOLIVAR,MARIA LA BAJA
-Colombia-Bolivar-Montecristo,municipality,Colombia,Bolivar,Montecristo,NA,BOLIVAR,MONTECRISTO
-Colombia-Bolivar-Mompos,municipality,Colombia,Bolivar,Mompos,NA,BOLIVAR,MOMPOS
-Colombia-Bolivar-Norosi,municipality,Colombia,Bolivar,Norosi,NA,BOLIVAR,NOROSI
-Colombia-Bolivar-Morales,municipality,Colombia,Bolivar,Morales,NA,BOLIVAR,MORALES
-Colombia-Bolivar-Pinillos,municipality,Colombia,Bolivar,Pinillos,NA,BOLIVAR,PINILLOS
-Colombia-Bolivar-Regidor,municipality,Colombia,Bolivar,Regidor,NA,BOLIVAR,REGIDOR
-Colombia-Bolivar-Rio_Viejo,municipality,Colombia,Bolivar,Rio_Viejo,NA,BOLIVAR,RIO VIEJO
-Colombia-Bolivar-San_Cristobal,municipality,Colombia,Bolivar,San_Cristobal,NA,BOLIVAR,SAN CRISTOBAL
-Colombia-Bolivar-San_Estanislao,municipality,Colombia,Bolivar,San_Estanislao,NA,BOLIVAR,SAN ESTANISLAO
-Colombia-Bolivar-San_Fernando,municipality,Colombia,Bolivar,San_Fernando,NA,BOLIVAR,SAN FERNANDO
-Colombia-Bolivar-San_Jacinto,municipality,Colombia,Bolivar,San_Jacinto,NA,BOLIVAR,SAN JACINTO
-Colombia-Bolivar-San_Jacinto_Del_Cauca,municipality,Colombia,Bolivar,San_Jacinto_Del_Cauca,NA,BOLIVAR,SAN JACINTO DEL CAUCA
-Colombia-Bolivar-San_Juan_Nepomuceno,municipality,Colombia,Bolivar,San_Juan_Nepomuceno,NA,BOLIVAR,SAN JUAN NEPOMUCENO
-Colombia-Bolivar-San_Martin_De_Loba,municipality,Colombia,Bolivar,San_Martin_De_Loba,NA,BOLIVAR,SAN MARTIN DE LOBA
-Colombia-Bolivar-San_Pablo,municipality,Colombia,Bolivar,San_Pablo,NA,BOLIVAR,SAN PABLO
-Colombia-Bolivar-Santa_Catalina,municipality,Colombia,Bolivar,Santa_Catalina,NA,BOLIVAR,SANTA CATALINA
-Colombia-Bolivar-Santa_Rosa,municipality,Colombia,Bolivar,Santa_Rosa,NA,BOLIVAR,SANTA ROSA
-Colombia-Bolivar-Santa_Rosa_Del_Sur,municipality,Colombia,Bolivar,Santa_Rosa_Del_Sur,NA,BOLIVAR,SANTA ROSA DEL SUR
-Colombia-Bolivar-Simiti,municipality,Colombia,Bolivar,Simiti,NA,BOLIVAR,SIMITI
-Colombia-Bolivar-Soplaviento,municipality,Colombia,Bolivar,Soplaviento,NA,BOLIVAR,SOPLAVIENTO
-Colombia-Bolivar-Talaigua_Nuevo,municipality,Colombia,Bolivar,Talaigua_Nuevo,NA,BOLIVAR,TALAIGUA NUEVO
-Colombia-Bolivar-Tiquisio,municipality,Colombia,Bolivar,Tiquisio,NA,BOLIVAR,TIQUISIO
-Colombia-Bolivar-Turbaco,municipality,Colombia,Bolivar,Turbaco,NA,BOLIVAR,TURBACO
-Colombia-Bolivar-Turbana,municipality,Colombia,Bolivar,Turbana,NA,BOLIVAR,TURBANA
-Colombia-Bolivar-Villanueva,municipality,Colombia,Bolivar,Villanueva,NA,BOLIVAR,VILLANUEVA
-Colombia-Bolivar-Zambrano,municipality,Colombia,Bolivar,Zambrano,NA,BOLIVAR,ZAMBRANO
-Colombia-Boyaca-Unknown,municipality,Colombia,Boyaca,Unknown,NA,BOYACA,* BOYACA. MUNICIPIO DESCONOCIDO
-Colombia-Boyaca-Tunja,municipality,Colombia,Boyaca,Tunja,NA,BOYACA,TUNJA
-Colombia-Boyaca-Almeida,municipality,Colombia,Boyaca,Almeida,NA,BOYACA,ALMEIDA
-Colombia-Boyaca-Aquitania,municipality,Colombia,Boyaca,Aquitania,NA,BOYACA,AQUITANIA
-Colombia-Boyaca-Arcabuco,municipality,Colombia,Boyaca,Arcabuco,NA,BOYACA,ARCABUCO
-Colombia-Boyaca-Belen,municipality,Colombia,Boyaca,Belen,NA,BOYACA,BELEN
-Colombia-Boyaca-Berbeo,municipality,Colombia,Boyaca,Berbeo,NA,BOYACA,BERBEO
-Colombia-Boyaca-Beteitiva,municipality,Colombia,Boyaca,Beteitiva,NA,BOYACA,BETEITIVA
-Colombia-Boyaca-Boavita,municipality,Colombia,Boyaca,Boavita,NA,BOYACA,BOAVITA
-Colombia-Boyaca-Boyaca,municipality,Colombia,Boyaca,Boyaca,NA,BOYACA,BOYACA
-Colombia-Boyaca-Briceno,municipality,Colombia,Boyaca,Briceno,NA,BOYACA,BRICEÑO
-Colombia-Boyaca-Buenavista,municipality,Colombia,Boyaca,Buenavista,NA,BOYACA,BUENAVISTA
-Colombia-Boyaca-Busbanza,municipality,Colombia,Boyaca,Busbanza,NA,BOYACA,BUSBANZA
-Colombia-Boyaca-Caldas,municipality,Colombia,Boyaca,Caldas,NA,BOYACA,CALDAS
-Colombia-Boyaca-Campohermoso,municipality,Colombia,Boyaca,Campohermoso,NA,BOYACA,CAMPOHERMOSO
-Colombia-Boyaca-Cerinza,municipality,Colombia,Boyaca,Cerinza,NA,BOYACA,CERINZA
-Colombia-Boyaca-Chinavita,municipality,Colombia,Boyaca,Chinavita,NA,BOYACA,CHINAVITA
-Colombia-Boyaca-Chiquinquira,municipality,Colombia,Boyaca,Chiquinquira,NA,BOYACA,CHIQUINQUIRA
-Colombia-Boyaca-Chiscas,municipality,Colombia,Boyaca,Chiscas,NA,BOYACA,CHISCAS
-Colombia-Boyaca-Chita,municipality,Colombia,Boyaca,Chita,NA,BOYACA,CHITA
-Colombia-Boyaca-Chitaraque,municipality,Colombia,Boyaca,Chitaraque,NA,BOYACA,CHITARAQUE
-Colombia-Boyaca-Chivata,municipality,Colombia,Boyaca,Chivata,NA,BOYACA,CHIVATA
-Colombia-Boyaca-Cienega,municipality,Colombia,Boyaca,Cienega,NA,BOYACA,CIENEGA
-Colombia-Boyaca-Combita,municipality,Colombia,Boyaca,Combita,NA,BOYACA,COMBITA
-Colombia-Boyaca-Coper,municipality,Colombia,Boyaca,Coper,NA,BOYACA,COPER
-Colombia-Boyaca-Corrales,municipality,Colombia,Boyaca,Corrales,NA,BOYACA,CORRALES
-Colombia-Boyaca-Covarachia,municipality,Colombia,Boyaca,Covarachia,NA,BOYACA,COVARACHIA
-Colombia-Boyaca-Cubara,municipality,Colombia,Boyaca,Cubara,NA,BOYACA,CUBARA
-Colombia-Boyaca-Cucaita,municipality,Colombia,Boyaca,Cucaita,NA,BOYACA,CUCAITA
-Colombia-Boyaca-Cuitiva,municipality,Colombia,Boyaca,Cuitiva,NA,BOYACA,CUITIVA
-Colombia-Boyaca-Chiquiza,municipality,Colombia,Boyaca,Chiquiza,NA,BOYACA,CHIQUIZA
-Colombia-Boyaca-Chivor,municipality,Colombia,Boyaca,Chivor,NA,BOYACA,CHIVOR
-Colombia-Boyaca-Duitama,municipality,Colombia,Boyaca,Duitama,NA,BOYACA,DUITAMA
-Colombia-Boyaca-El_Cocuy,municipality,Colombia,Boyaca,El_Cocuy,NA,BOYACA,EL COCUY
-Colombia-Boyaca-El_Espino,municipality,Colombia,Boyaca,El_Espino,NA,BOYACA,EL ESPINO
-Colombia-Boyaca-Firavitoba,municipality,Colombia,Boyaca,Firavitoba,NA,BOYACA,FIRAVITOBA
-Colombia-Boyaca-Floresta,municipality,Colombia,Boyaca,Floresta,NA,BOYACA,FLORESTA
-Colombia-Boyaca-Gachantiva,municipality,Colombia,Boyaca,Gachantiva,NA,BOYACA,GACHANTIVA
-Colombia-Boyaca-Gameza,municipality,Colombia,Boyaca,Gameza,NA,BOYACA,GAMEZA
-Colombia-Boyaca-Garagoa,municipality,Colombia,Boyaca,Garagoa,NA,BOYACA,GARAGOA
-Colombia-Boyaca-Guacamayas,municipality,Colombia,Boyaca,Guacamayas,NA,BOYACA,GUACAMAYAS
-Colombia-Boyaca-Guateque,municipality,Colombia,Boyaca,Guateque,NA,BOYACA,GUATEQUE
-Colombia-Boyaca-Guayata,municipality,Colombia,Boyaca,Guayata,NA,BOYACA,GUAYATA
-Colombia-Boyaca-Guican,municipality,Colombia,Boyaca,Guican,NA,BOYACA,GUICAN
-Colombia-Boyaca-Iza,municipality,Colombia,Boyaca,Iza,NA,BOYACA,IZA
-Colombia-Boyaca-Jenesano,municipality,Colombia,Boyaca,Jenesano,NA,BOYACA,JENESANO
-Colombia-Boyaca-Jerico,municipality,Colombia,Boyaca,Jerico,NA,BOYACA,JERICO
-Colombia-Boyaca-Labranzagrande,municipality,Colombia,Boyaca,Labranzagrande,NA,BOYACA,LABRANZAGRANDE
-Colombia-Boyaca-La_Capilla,municipality,Colombia,Boyaca,La_Capilla,NA,BOYACA,LA CAPILLA
-Colombia-Boyaca-La_Victoria,municipality,Colombia,Boyaca,La_Victoria,NA,BOYACA,LA VICTORIA
-Colombia-Boyaca-La_Uvita,municipality,Colombia,Boyaca,La_Uvita,NA,BOYACA,LA UVITA
-Colombia-Boyaca-Villa_De_Leyva,municipality,Colombia,Boyaca,Villa_De_Leyva,NA,BOYACA,VILLA DE LEYVA
-Colombia-Boyaca-Macanal,municipality,Colombia,Boyaca,Macanal,NA,BOYACA,MACANAL
-Colombia-Boyaca-Maripi,municipality,Colombia,Boyaca,Maripi,NA,BOYACA,MARIPI
-Colombia-Boyaca-Miraflores,municipality,Colombia,Boyaca,Miraflores,NA,BOYACA,MIRAFLORES
-Colombia-Boyaca-Mongua,municipality,Colombia,Boyaca,Mongua,NA,BOYACA,MONGUA
-Colombia-Boyaca-Mongui,municipality,Colombia,Boyaca,Mongui,NA,BOYACA,MONGUI
-Colombia-Boyaca-Moniquira,municipality,Colombia,Boyaca,Moniquira,NA,BOYACA,MONIQUIRA
-Colombia-Boyaca-Motavita,municipality,Colombia,Boyaca,Motavita,NA,BOYACA,MOTAVITA
-Colombia-Boyaca-Muzo,municipality,Colombia,Boyaca,Muzo,NA,BOYACA,MUZO
-Colombia-Boyaca-Nobsa,municipality,Colombia,Boyaca,Nobsa,NA,BOYACA,NOBSA
-Colombia-Boyaca-Nuevo_Colon,municipality,Colombia,Boyaca,Nuevo_Colon,NA,BOYACA,NUEVO COLON
-Colombia-Boyaca-Oicata,municipality,Colombia,Boyaca,Oicata,NA,BOYACA,OICATA
-Colombia-Boyaca-Otanche,municipality,Colombia,Boyaca,Otanche,NA,BOYACA,OTANCHE
-Colombia-Boyaca-Pachavita,municipality,Colombia,Boyaca,Pachavita,NA,BOYACA,PACHAVITA
-Colombia-Boyaca-Paez,municipality,Colombia,Boyaca,Paez,NA,BOYACA,PAEZ
-Colombia-Boyaca-Paipa,municipality,Colombia,Boyaca,Paipa,NA,BOYACA,PAIPA
-Colombia-Boyaca-Pajarito,municipality,Colombia,Boyaca,Pajarito,NA,BOYACA,PAJARITO
-Colombia-Boyaca-Panqueba,municipality,Colombia,Boyaca,Panqueba,NA,BOYACA,PANQUEBA
-Colombia-Boyaca-Pauna,municipality,Colombia,Boyaca,Pauna,NA,BOYACA,PAUNA
-Colombia-Boyaca-Paya,municipality,Colombia,Boyaca,Paya,NA,BOYACA,PAYA
-Colombia-Boyaca-Paz_De_Rio,municipality,Colombia,Boyaca,Paz_De_Rio,NA,BOYACA,PAZ DE RIO
-Colombia-Boyaca-Pesca,municipality,Colombia,Boyaca,Pesca,NA,BOYACA,PESCA
-Colombia-Boyaca-Pisba,municipality,Colombia,Boyaca,Pisba,NA,BOYACA,PISBA
-Colombia-Boyaca-Puerto_Boyaca,municipality,Colombia,Boyaca,Puerto_Boyaca,NA,BOYACA,PUERTO BOYACA
-Colombia-Boyaca-Quipama,municipality,Colombia,Boyaca,Quipama,NA,BOYACA,QUIPAMA
-Colombia-Boyaca-Ramiriqui,municipality,Colombia,Boyaca,Ramiriqui,NA,BOYACA,RAMIRIQUI
-Colombia-Boyaca-Raquira,municipality,Colombia,Boyaca,Raquira,NA,BOYACA,RAQUIRA
-Colombia-Boyaca-Rondon,municipality,Colombia,Boyaca,Rondon,NA,BOYACA,RONDON
-Colombia-Boyaca-Saboya,municipality,Colombia,Boyaca,Saboya,NA,BOYACA,SABOYA
-Colombia-Boyaca-Sachica,municipality,Colombia,Boyaca,Sachica,NA,BOYACA,SACHICA
-Colombia-Boyaca-Samaca,municipality,Colombia,Boyaca,Samaca,NA,BOYACA,SAMACA
-Colombia-Boyaca-San_Eduardo,municipality,Colombia,Boyaca,San_Eduardo,NA,BOYACA,SAN EDUARDO
-Colombia-Boyaca-San_Jose_De_Pare,municipality,Colombia,Boyaca,San_Jose_De_Pare,NA,BOYACA,SAN JOSE DE PARE
-Colombia-Boyaca-San_Luis_De_Gaceno,municipality,Colombia,Boyaca,San_Luis_De_Gaceno,NA,BOYACA,SAN LUIS DE GACENO
-Colombia-Boyaca-San_Mateo,municipality,Colombia,Boyaca,San_Mateo,NA,BOYACA,SAN MATEO
-Colombia-Boyaca-San_Miguel_De_Sema,municipality,Colombia,Boyaca,San_Miguel_De_Sema,NA,BOYACA,SAN MIGUEL DE SEMA
-Colombia-Boyaca-San_Pablo_De_Borbur,municipality,Colombia,Boyaca,San_Pablo_De_Borbur,NA,BOYACA,SAN PABLO DE BORBUR
-Colombia-Boyaca-Santana,municipality,Colombia,Boyaca,Santana,NA,BOYACA,SANTANA
-Colombia-Boyaca-Santa_Maria,municipality,Colombia,Boyaca,Santa_Maria,NA,BOYACA,SANTA MARIA
-Colombia-Boyaca-Santa_Rosa_De_Viterbo,municipality,Colombia,Boyaca,Santa_Rosa_De_Viterbo,NA,BOYACA,SANTA ROSA DE VITERBO
-Colombia-Boyaca-Santa_Sofia,municipality,Colombia,Boyaca,Santa_Sofia,NA,BOYACA,SANTA SOFIA
-Colombia-Boyaca-Sativanorte,municipality,Colombia,Boyaca,Sativanorte,NA,BOYACA,SATIVANORTE
-Colombia-Boyaca-Sativasur,municipality,Colombia,Boyaca,Sativasur,NA,BOYACA,SATIVASUR
-Colombia-Boyaca-Siachoque,municipality,Colombia,Boyaca,Siachoque,NA,BOYACA,SIACHOQUE
-Colombia-Boyaca-Soata,municipality,Colombia,Boyaca,Soata,NA,BOYACA,SOATA
-Colombia-Boyaca-Socota,municipality,Colombia,Boyaca,Socota,NA,BOYACA,SOCOTA
-Colombia-Boyaca-Socha,municipality,Colombia,Boyaca,Socha,NA,BOYACA,SOCHA
-Colombia-Boyaca-Sogamoso,municipality,Colombia,Boyaca,Sogamoso,NA,BOYACA,SOGAMOSO
-Colombia-Boyaca-Somondoco,municipality,Colombia,Boyaca,Somondoco,NA,BOYACA,SOMONDOCO
-Colombia-Boyaca-Sora,municipality,Colombia,Boyaca,Sora,NA,BOYACA,SORA
-Colombia-Boyaca-Sotaquira,municipality,Colombia,Boyaca,Sotaquira,NA,BOYACA,SOTAQUIRA
-Colombia-Boyaca-Soraca,municipality,Colombia,Boyaca,Soraca,NA,BOYACA,SORACA
-Colombia-Boyaca-Susacon,municipality,Colombia,Boyaca,Susacon,NA,BOYACA,SUSACON
-Colombia-Boyaca-Sutamarchan,municipality,Colombia,Boyaca,Sutamarchan,NA,BOYACA,SUTAMARCHAN
-Colombia-Boyaca-Sutatenza,municipality,Colombia,Boyaca,Sutatenza,NA,BOYACA,SUTATENZA
-Colombia-Boyaca-Tasco,municipality,Colombia,Boyaca,Tasco,NA,BOYACA,TASCO
-Colombia-Boyaca-Tenza,municipality,Colombia,Boyaca,Tenza,NA,BOYACA,TENZA
-Colombia-Boyaca-Tibana,municipality,Colombia,Boyaca,Tibana,NA,BOYACA,TIBANA
-Colombia-Boyaca-Tibasosa,municipality,Colombia,Boyaca,Tibasosa,NA,BOYACA,TIBASOSA
-Colombia-Boyaca-Tinjaca,municipality,Colombia,Boyaca,Tinjaca,NA,BOYACA,TINJACA
-Colombia-Boyaca-Tipacoque,municipality,Colombia,Boyaca,Tipacoque,NA,BOYACA,TIPACOQUE
-Colombia-Boyaca-Toca,municipality,Colombia,Boyaca,Toca,NA,BOYACA,TOCA
-Colombia-Boyaca-Togui,municipality,Colombia,Boyaca,Togui,NA,BOYACA,TOGUÍ
-Colombia-Boyaca-Topaga,municipality,Colombia,Boyaca,Topaga,NA,BOYACA,TOPAGA
-Colombia-Boyaca-Tota,municipality,Colombia,Boyaca,Tota,NA,BOYACA,TOTA
-Colombia-Boyaca-Tunungua,municipality,Colombia,Boyaca,Tunungua,NA,BOYACA,TUNUNGUA
-Colombia-Boyaca-Turmeque,municipality,Colombia,Boyaca,Turmeque,NA,BOYACA,TURMEQUE
-Colombia-Boyaca-Tuta,municipality,Colombia,Boyaca,Tuta,NA,BOYACA,TUTA
-Colombia-Boyaca-Tutaza,municipality,Colombia,Boyaca,Tutaza,NA,BOYACA,TUTAZA
-Colombia-Boyaca-Umbita,municipality,Colombia,Boyaca,Umbita,NA,BOYACA,UMBITA
-Colombia-Boyaca-Ventaquemada,municipality,Colombia,Boyaca,Ventaquemada,NA,BOYACA,VENTAQUEMADA
-Colombia-Boyaca-Viracacha,municipality,Colombia,Boyaca,Viracacha,NA,BOYACA,VIRACACHA
-Colombia-Boyaca-Zetaquira,municipality,Colombia,Boyaca,Zetaquira,NA,BOYACA,ZETAQUIRA
-Colombia-Caldas-Unknown,municipality,Colombia,Caldas,Unknown,NA,CALDAS,* CALDAS. MUNICIPIO DESCONOCIDO
-Colombia-Caldas-Manizales,municipality,Colombia,Caldas,Manizales,NA,CALDAS,MANIZALES
-Colombia-Caldas-Aguadas,municipality,Colombia,Caldas,Aguadas,NA,CALDAS,AGUADAS
-Colombia-Caldas-Anserma,municipality,Colombia,Caldas,Anserma,NA,CALDAS,ANSERMA
-Colombia-Caldas-Aranzazu,municipality,Colombia,Caldas,Aranzazu,NA,CALDAS,ARANZAZU
-Colombia-Caldas-Belalcazar,municipality,Colombia,Caldas,Belalcazar,NA,CALDAS,BELALCAZAR
-Colombia-Caldas-Chinchina,municipality,Colombia,Caldas,Chinchina,NA,CALDAS,CHINCHINA
-Colombia-Caldas-Filadelfia,municipality,Colombia,Caldas,Filadelfia,NA,CALDAS,FILADELFIA
-Colombia-Caldas-La_Dorada,municipality,Colombia,Caldas,La_Dorada,NA,CALDAS,LA DORADA
-Colombia-Caldas-La_Merced,municipality,Colombia,Caldas,La_Merced,NA,CALDAS,LA MERCED
-Colombia-Caldas-Manzanares,municipality,Colombia,Caldas,Manzanares,NA,CALDAS,MANZANARES
-Colombia-Caldas-Marmato,municipality,Colombia,Caldas,Marmato,NA,CALDAS,MARMATO
-Colombia-Caldas-Marquetalia,municipality,Colombia,Caldas,Marquetalia,NA,CALDAS,MARQUETALIA
-Colombia-Caldas-Marulanda,municipality,Colombia,Caldas,Marulanda,NA,CALDAS,MARULANDA
-Colombia-Caldas-Neira,municipality,Colombia,Caldas,Neira,NA,CALDAS,NEIRA
-Colombia-Caldas-Norcasia,municipality,Colombia,Caldas,Norcasia,NA,CALDAS,NORCASIA
-Colombia-Caldas-Pacora,municipality,Colombia,Caldas,Pacora,NA,CALDAS,PACORA
-Colombia-Caldas-Palestina,municipality,Colombia,Caldas,Palestina,NA,CALDAS,PALESTINA
-Colombia-Caldas-Pensilvania,municipality,Colombia,Caldas,Pensilvania,NA,CALDAS,PENSILVANIA
-Colombia-Caldas-Riosucio,municipality,Colombia,Caldas,Riosucio,NA,CALDAS,RIOSUCIO
-Colombia-Caldas-Risaralda,municipality,Colombia,Caldas,Risaralda,NA,CALDAS,RISARALDA
-Colombia-Caldas-Salamina,municipality,Colombia,Caldas,Salamina,NA,CALDAS,SALAMINA
-Colombia-Caldas-Samana,municipality,Colombia,Caldas,Samana,NA,CALDAS,SAMANA
-Colombia-Caldas-San_Jose,municipality,Colombia,Caldas,San_Jose,NA,CALDAS,SAN JOSE
-Colombia-Caldas-Supia,municipality,Colombia,Caldas,Supia,NA,CALDAS,SUPIA
-Colombia-Caldas-Victoria,municipality,Colombia,Caldas,Victoria,NA,CALDAS,VICTORIA
-Colombia-Caldas-Villamaria,municipality,Colombia,Caldas,Villamaria,NA,CALDAS,VILLAMARIA
-Colombia-Caldas-Viterbo,municipality,Colombia,Caldas,Viterbo,NA,CALDAS,VITERBO
-Colombia-Caqueta-Unknown,municipality,Colombia,Caqueta,Unknown,NA,CAQUETA,* CAQUETA. MUNICIPIO DESCONOCIDO
-Colombia-Caqueta-Florencia,municipality,Colombia,Caqueta,Florencia,NA,CAQUETA,FLORENCIA
-Colombia-Caqueta-Albania,municipality,Colombia,Caqueta,Albania,NA,CAQUETA,ALBANIA
-Colombia-Caqueta-Belen_De_Los_Andaquies,municipality,Colombia,Caqueta,Belen_De_Los_Andaquies,NA,CAQUETA,BELEN DE LOS ANDAQUIES
-Colombia-Caqueta-Cartagena_Del_Chaira,municipality,Colombia,Caqueta,Cartagena_Del_Chaira,NA,CAQUETA,CARTAGENA DEL CHAIRA
-Colombia-Caqueta-Curillo,municipality,Colombia,Caqueta,Curillo,NA,CAQUETA,CURILLO
-Colombia-Caqueta-El_Doncello,municipality,Colombia,Caqueta,El_Doncello,NA,CAQUETA,EL DONCELLO
-Colombia-Caqueta-El_Paujil,municipality,Colombia,Caqueta,El_Paujil,NA,CAQUETA,EL PAUJIL
-Colombia-Caqueta-La_Montanita,municipality,Colombia,Caqueta,La_Montanita,NA,CAQUETA,LA MONTAÑITA
-Colombia-Caqueta-Milan,municipality,Colombia,Caqueta,Milan,NA,CAQUETA,MILAN
-Colombia-Caqueta-Morelia,municipality,Colombia,Caqueta,Morelia,NA,CAQUETA,MORELIA
-Colombia-Caqueta-Puerto_Rico,municipality,Colombia,Caqueta,Puerto_Rico,NA,CAQUETA,PUERTO RICO
-Colombia-Caqueta-San_Jose_Del_Fragua,municipality,Colombia,Caqueta,San_Jose_Del_Fragua,NA,CAQUETA,SAN JOSE DEL FRAGUA
-Colombia-Caqueta-San_Vicente_Del_Caguan,municipality,Colombia,Caqueta,San_Vicente_Del_Caguan,NA,CAQUETA,SAN VICENTE DEL CAGUAN
-Colombia-Caqueta-Solano,municipality,Colombia,Caqueta,Solano,NA,CAQUETA,SOLANO
-Colombia-Caqueta-Solita,municipality,Colombia,Caqueta,Solita,NA,CAQUETA,SOLITA
-Colombia-Caqueta-Valparaiso,municipality,Colombia,Caqueta,Valparaiso,NA,CAQUETA,VALPARAISO
-Colombia-Cauca-Unknown,municipality,Colombia,Cauca,Unknown,NA,CAUCA,* CAUCA. MUNICIPIO DESCONOCIDO
-Colombia-Cauca-Popayan,municipality,Colombia,Cauca,Popayan,NA,CAUCA,POPAYAN
-Colombia-Cauca-Almaguer,municipality,Colombia,Cauca,Almaguer,NA,CAUCA,ALMAGUER
-Colombia-Cauca-Argelia,municipality,Colombia,Cauca,Argelia,NA,CAUCA,ARGELIA
-Colombia-Cauca-Balboa,municipality,Colombia,Cauca,Balboa,NA,CAUCA,BALBOA
-Colombia-Cauca-Bolivar,municipality,Colombia,Cauca,Bolivar,NA,CAUCA,BOLIVAR
-Colombia-Cauca-Buenos_Aires,municipality,Colombia,Cauca,Buenos_Aires,NA,CAUCA,BUENOS AIRES
-Colombia-Cauca-Cajibio,municipality,Colombia,Cauca,Cajibio,NA,CAUCA,CAJIBIO
-Colombia-Cauca-Caldono,municipality,Colombia,Cauca,Caldono,NA,CAUCA,CALDONO
-Colombia-Cauca-Caloto,municipality,Colombia,Cauca,Caloto,NA,CAUCA,CALOTO
-Colombia-Cauca-Corinto,municipality,Colombia,Cauca,Corinto,NA,CAUCA,CORINTO
-Colombia-Cauca-El_Tambo,municipality,Colombia,Cauca,El_Tambo,NA,CAUCA,EL TAMBO
-Colombia-Cauca-Florencia,municipality,Colombia,Cauca,Florencia,NA,CAUCA,FLORENCIA
-Colombia-Cauca-Guachene,municipality,Colombia,Cauca,Guachene,NA,CAUCA,GUACHENE
-Colombia-Cauca-Guapi,municipality,Colombia,Cauca,Guapi,NA,CAUCA,GUAPI
-Colombia-Cauca-Inza,municipality,Colombia,Cauca,Inza,NA,CAUCA,INZA
-Colombia-Cauca-Jambalo,municipality,Colombia,Cauca,Jambalo,NA,CAUCA,JAMBALO
-Colombia-Cauca-La_Sierra,municipality,Colombia,Cauca,La_Sierra,NA,CAUCA,LA SIERRA
-Colombia-Cauca-La_Vega,municipality,Colombia,Cauca,La_Vega,NA,CAUCA,LA VEGA
-Colombia-Cauca-Lopez,municipality,Colombia,Cauca,Lopez,NA,CAUCA,LOPEZ
-Colombia-Cauca-Mercaderes,municipality,Colombia,Cauca,Mercaderes,NA,CAUCA,MERCADERES
-Colombia-Cauca-Miranda,municipality,Colombia,Cauca,Miranda,NA,CAUCA,MIRANDA
-Colombia-Cauca-Morales,municipality,Colombia,Cauca,Morales,NA,CAUCA,MORALES
-Colombia-Cauca-Padilla,municipality,Colombia,Cauca,Padilla,NA,CAUCA,PADILLA
-Colombia-Cauca-Paez,municipality,Colombia,Cauca,Paez,NA,CAUCA,PAEZ
-Colombia-Cauca-Patia,municipality,Colombia,Cauca,Patia,NA,CAUCA,PATIA
-Colombia-Cauca-Piamonte,municipality,Colombia,Cauca,Piamonte,NA,CAUCA,PIAMONTE
-Colombia-Cauca-Piendamo,municipality,Colombia,Cauca,Piendamo,NA,CAUCA,PIENDAMO
-Colombia-Cauca-Puerto_Tejada,municipality,Colombia,Cauca,Puerto_Tejada,NA,CAUCA,PUERTO TEJADA
-Colombia-Cauca-Purace,municipality,Colombia,Cauca,Purace,NA,CAUCA,PURACE
-Colombia-Cauca-Rosas,municipality,Colombia,Cauca,Rosas,NA,CAUCA,ROSAS
-Colombia-Cauca-San_Sebastian,municipality,Colombia,Cauca,San_Sebastian,NA,CAUCA,SAN SEBASTIAN
-Colombia-Cauca-Santander_De_Quilichao,municipality,Colombia,Cauca,Santander_De_Quilichao,NA,CAUCA,SANTANDER DE QUILICHAO
-Colombia-Cauca-Santa_Rosa,municipality,Colombia,Cauca,Santa_Rosa,NA,CAUCA,SANTA ROSA
-Colombia-Cauca-Silvia,municipality,Colombia,Cauca,Silvia,NA,CAUCA,SILVIA
-Colombia-Cauca-Sotara,municipality,Colombia,Cauca,Sotara,NA,CAUCA,SOTARA
-Colombia-Cauca-Suarez,municipality,Colombia,Cauca,Suarez,NA,CAUCA,SUAREZ
-Colombia-Cauca-Sucre,municipality,Colombia,Cauca,Sucre,NA,CAUCA,SUCRE
-Colombia-Cauca-Timbio,municipality,Colombia,Cauca,Timbio,NA,CAUCA,TIMBIO
-Colombia-Cauca-Timbiqui,municipality,Colombia,Cauca,Timbiqui,NA,CAUCA,TIMBIQUI
-Colombia-Cauca-Toribio,municipality,Colombia,Cauca,Toribio,NA,CAUCA,TORIBIO
-Colombia-Cauca-Totoro,municipality,Colombia,Cauca,Totoro,NA,CAUCA,TOTORO
-Colombia-Cauca-Villa_Rica,municipality,Colombia,Cauca,Villa_Rica,NA,CAUCA,VILLA RICA
-Colombia-Cesar-Unknown,municipality,Colombia,Cesar,Unknown,NA,CESAR,* CESAR. MUNICIPIO DESCONOCIDO
-Colombia-Cesar-Valledupar,municipality,Colombia,Cesar,Valledupar,NA,CESAR,VALLEDUPAR
-Colombia-Cesar-Aguachica,municipality,Colombia,Cesar,Aguachica,NA,CESAR,AGUACHICA
-Colombia-Cesar-Agustin_Codazzi,municipality,Colombia,Cesar,Agustin_Codazzi,NA,CESAR,AGUSTIN CODAZZI
-Colombia-Cesar-Astrea,municipality,Colombia,Cesar,Astrea,NA,CESAR,ASTREA
-Colombia-Cesar-Becerril,municipality,Colombia,Cesar,Becerril,NA,CESAR,BECERRIL
-Colombia-Cesar-Bosconia,municipality,Colombia,Cesar,Bosconia,NA,CESAR,BOSCONIA
-Colombia-Cesar-Chimichagua,municipality,Colombia,Cesar,Chimichagua,NA,CESAR,CHIMICHAGUA
-Colombia-Cesar-Chiriguana,municipality,Colombia,Cesar,Chiriguana,NA,CESAR,CHIRIGUANA
-Colombia-Cesar-Curumani,municipality,Colombia,Cesar,Curumani,NA,CESAR,CURUMANI
-Colombia-Cesar-El_Copey,municipality,Colombia,Cesar,El_Copey,NA,CESAR,EL COPEY
-Colombia-Cesar-El_Paso,municipality,Colombia,Cesar,El_Paso,NA,CESAR,EL PASO
-Colombia-Cesar-Gamarra,municipality,Colombia,Cesar,Gamarra,NA,CESAR,GAMARRA
-Colombia-Cesar-Gonzalez,municipality,Colombia,Cesar,Gonzalez,NA,CESAR,GONZALEZ
-Colombia-Cesar-La_Gloria,municipality,Colombia,Cesar,La_Gloria,NA,CESAR,LA GLORIA
-Colombia-Cesar-La_Jagua_De_Ibirico,municipality,Colombia,Cesar,La_Jagua_De_Ibirico,NA,CESAR,LA JAGUA DE IBIRICO
-Colombia-Cesar-Manaure,municipality,Colombia,Cesar,Manaure,NA,CESAR,MANAURE
-Colombia-Cesar-Pailitas,municipality,Colombia,Cesar,Pailitas,NA,CESAR,PAILITAS
-Colombia-Cesar-Pelaya,municipality,Colombia,Cesar,Pelaya,NA,CESAR,PELAYA
-Colombia-Cesar-Pueblo_Bello,municipality,Colombia,Cesar,Pueblo_Bello,NA,CESAR,PUEBLO BELLO
-Colombia-Cesar-Rio_De_Oro,municipality,Colombia,Cesar,Rio_De_Oro,NA,CESAR,RIO DE ORO
-Colombia-Cesar-La_Paz,municipality,Colombia,Cesar,La_Paz,NA,CESAR,LA PAZ
-Colombia-Cesar-San_Alberto,municipality,Colombia,Cesar,San_Alberto,NA,CESAR,SAN ALBERTO
-Colombia-Cesar-San_Diego,municipality,Colombia,Cesar,San_Diego,NA,CESAR,SAN DIEGO
-Colombia-Cesar-San_Martin,municipality,Colombia,Cesar,San_Martin,NA,CESAR,SAN MARTIN
-Colombia-Cesar-Tamalameque,municipality,Colombia,Cesar,Tamalameque,NA,CESAR,TAMALAMEQUE
-Colombia-Cordoba-Unknown,municipality,Colombia,Cordoba,Unknown,NA,CORDOBA,* CORDOBA. MUNICIPIO DESCONOCIDO
-Colombia-Cordoba-Monteria,municipality,Colombia,Cordoba,Monteria,NA,CORDOBA,MONTERIA
-Colombia-Cordoba-Ayapel,municipality,Colombia,Cordoba,Ayapel,NA,CORDOBA,AYAPEL
-Colombia-Cordoba-Buenavista,municipality,Colombia,Cordoba,Buenavista,NA,CORDOBA,BUENAVISTA
-Colombia-Cordoba-Canalete,municipality,Colombia,Cordoba,Canalete,NA,CORDOBA,CANALETE
-Colombia-Cordoba-Cerete,municipality,Colombia,Cordoba,Cerete,NA,CORDOBA,CERETE
-Colombia-Cordoba-Chima,municipality,Colombia,Cordoba,Chima,NA,CORDOBA,CHIMA
-Colombia-Cordoba-Chinu,municipality,Colombia,Cordoba,Chinu,NA,CORDOBA,CHINU
-Colombia-Cordoba-Cienaga_De_Oro,municipality,Colombia,Cordoba,Cienaga_De_Oro,NA,CORDOBA,CIENAGA DE ORO
-Colombia-Cordoba-Cotorra,municipality,Colombia,Cordoba,Cotorra,NA,CORDOBA,COTORRA
-Colombia-Cordoba-La_Apartada,municipality,Colombia,Cordoba,La_Apartada,NA,CORDOBA,LA APARTADA
-Colombia-Cordoba-Lorica,municipality,Colombia,Cordoba,Lorica,NA,CORDOBA,LORICA
-Colombia-Cordoba-Los_Cordobas,municipality,Colombia,Cordoba,Los_Cordobas,NA,CORDOBA,LOS CORDOBAS
-Colombia-Cordoba-Momil,municipality,Colombia,Cordoba,Momil,NA,CORDOBA,MOMIL
-Colombia-Cordoba-Montelibano,municipality,Colombia,Cordoba,Montelibano,NA,CORDOBA,MONTELIBANO
-Colombia-Cordoba-Monitos,municipality,Colombia,Cordoba,Monitos,NA,CORDOBA,MOÑITOS
-Colombia-Cordoba-Planeta_Rica,municipality,Colombia,Cordoba,Planeta_Rica,NA,CORDOBA,PLANETA RICA
-Colombia-Cordoba-Pueblo_Nuevo,municipality,Colombia,Cordoba,Pueblo_Nuevo,NA,CORDOBA,PUEBLO NUEVO
-Colombia-Cordoba-Puerto_Escondido,municipality,Colombia,Cordoba,Puerto_Escondido,NA,CORDOBA,PUERTO ESCONDIDO
-Colombia-Cordoba-Puerto_Libertador,municipality,Colombia,Cordoba,Puerto_Libertador,NA,CORDOBA,PUERTO LIBERTADOR
-Colombia-Cordoba-Purisima,municipality,Colombia,Cordoba,Purisima,NA,CORDOBA,PURISIMA
-Colombia-Cordoba-Sahagun,municipality,Colombia,Cordoba,Sahagun,NA,CORDOBA,SAHAGUN
-Colombia-Cordoba-San_Andres_Sotavento,municipality,Colombia,Cordoba,San_Andres_Sotavento,NA,CORDOBA,SAN ANDRES SOTAVENTO
-Colombia-Cordoba-San_Antero,municipality,Colombia,Cordoba,San_Antero,NA,CORDOBA,SAN ANTERO
-Colombia-Cordoba-San_Bernardo_Del_Viento,municipality,Colombia,Cordoba,San_Bernardo_Del_Viento,NA,CORDOBA,SAN BERNARDO DEL VIENTO
-Colombia-Cordoba-San_Carlos,municipality,Colombia,Cordoba,San_Carlos,NA,CORDOBA,SAN CARLOS
-Colombia-Cordoba-San_Jose_De_Ure,municipality,Colombia,Cordoba,San_Jose_De_Ure,NA,CORDOBA,SAN JOSE DE URE
-Colombia-Cordoba-San_Pelayo,municipality,Colombia,Cordoba,San_Pelayo,NA,CORDOBA,SAN PELAYO
-Colombia-Cordoba-Tierralta,municipality,Colombia,Cordoba,Tierralta,NA,CORDOBA,TIERRALTA
-Colombia-Cordoba-Tuchin,municipality,Colombia,Cordoba,Tuchin,NA,CORDOBA,TUCHIN
-Colombia-Cordoba-Valencia,municipality,Colombia,Cordoba,Valencia,NA,CORDOBA,VALENCIA
-Colombia-Cundinamarca-Unknown,municipality,Colombia,Cundinamarca,Unknown,NA,CUNDINAMARCA,* CUNDINAMARCA. MUNICIPIO DESCONOCIDO
-Colombia-Cundinamarca-Agua_De_Dios,municipality,Colombia,Cundinamarca,Agua_De_Dios,NA,CUNDINAMARCA,AGUA DE DIOS
-Colombia-Cundinamarca-Alban,municipality,Colombia,Cundinamarca,Alban,NA,CUNDINAMARCA,ALBAN
-Colombia-Cundinamarca-Anapoima,municipality,Colombia,Cundinamarca,Anapoima,NA,CUNDINAMARCA,ANAPOIMA
-Colombia-Cundinamarca-Anolaima,municipality,Colombia,Cundinamarca,Anolaima,NA,CUNDINAMARCA,ANOLAIMA
-Colombia-Cundinamarca-Arbelaez,municipality,Colombia,Cundinamarca,Arbelaez,NA,CUNDINAMARCA,ARBELAEZ
-Colombia-Cundinamarca-Beltran,municipality,Colombia,Cundinamarca,Beltran,NA,CUNDINAMARCA,BELTRAN
-Colombia-Cundinamarca-Bituima,municipality,Colombia,Cundinamarca,Bituima,NA,CUNDINAMARCA,BITUIMA
-Colombia-Cundinamarca-Bojaca,municipality,Colombia,Cundinamarca,Bojaca,NA,CUNDINAMARCA,BOJACA
-Colombia-Cundinamarca-Cabrera,municipality,Colombia,Cundinamarca,Cabrera,NA,CUNDINAMARCA,CABRERA
-Colombia-Cundinamarca-Cachipay,municipality,Colombia,Cundinamarca,Cachipay,NA,CUNDINAMARCA,CACHIPAY
-Colombia-Cundinamarca-Cajica,municipality,Colombia,Cundinamarca,Cajica,NA,CUNDINAMARCA,CAJICA
-Colombia-Cundinamarca-Caparrapi,municipality,Colombia,Cundinamarca,Caparrapi,NA,CUNDINAMARCA,CAPARRAPI
-Colombia-Cundinamarca-Caqueza,municipality,Colombia,Cundinamarca,Caqueza,NA,CUNDINAMARCA,CAQUEZA
-Colombia-Cundinamarca-Carmen_De_Carupa,municipality,Colombia,Cundinamarca,Carmen_De_Carupa,NA,CUNDINAMARCA,CARMEN DE CARUPA
-Colombia-Cundinamarca-Chaguani,municipality,Colombia,Cundinamarca,Chaguani,NA,CUNDINAMARCA,CHAGUANI
-Colombia-Cundinamarca-Chia,municipality,Colombia,Cundinamarca,Chia,NA,CUNDINAMARCA,CHIA
-Colombia-Cundinamarca-Chipaque,municipality,Colombia,Cundinamarca,Chipaque,NA,CUNDINAMARCA,CHIPAQUE
-Colombia-Cundinamarca-Choachi,municipality,Colombia,Cundinamarca,Choachi,NA,CUNDINAMARCA,CHOACHI
-Colombia-Cundinamarca-Choconta,municipality,Colombia,Cundinamarca,Choconta,NA,CUNDINAMARCA,CHOCONTA
-Colombia-Cundinamarca-Cogua,municipality,Colombia,Cundinamarca,Cogua,NA,CUNDINAMARCA,COGUA
-Colombia-Cundinamarca-Cota,municipality,Colombia,Cundinamarca,Cota,NA,CUNDINAMARCA,COTA
-Colombia-Cundinamarca-Cucunuba,municipality,Colombia,Cundinamarca,Cucunuba,NA,CUNDINAMARCA,CUCUNUBA
-Colombia-Cundinamarca-El_Colegio,municipality,Colombia,Cundinamarca,El_Colegio,NA,CUNDINAMARCA,EL COLEGIO
-Colombia-Cundinamarca-El_Penon,municipality,Colombia,Cundinamarca,El_Penon,NA,CUNDINAMARCA,EL PEÑON
-Colombia-Cundinamarca-El_Rosal,municipality,Colombia,Cundinamarca,El_Rosal,NA,CUNDINAMARCA,EL ROSAL
-Colombia-Cundinamarca-Facatativa,municipality,Colombia,Cundinamarca,Facatativa,NA,CUNDINAMARCA,FACATATIVA
-Colombia-Cundinamarca-Fomeque,municipality,Colombia,Cundinamarca,Fomeque,NA,CUNDINAMARCA,FOMEQUE
-Colombia-Cundinamarca-Fosca,municipality,Colombia,Cundinamarca,Fosca,NA,CUNDINAMARCA,FOSCA
-Colombia-Cundinamarca-Funza,municipality,Colombia,Cundinamarca,Funza,NA,CUNDINAMARCA,FUNZA
-Colombia-Cundinamarca-Fuquene,municipality,Colombia,Cundinamarca,Fuquene,NA,CUNDINAMARCA,FUQUENE
-Colombia-Cundinamarca-Fusagasuga,municipality,Colombia,Cundinamarca,Fusagasuga,NA,CUNDINAMARCA,FUSAGASUGA
-Colombia-Cundinamarca-Gachala,municipality,Colombia,Cundinamarca,Gachala,NA,CUNDINAMARCA,GACHALA
-Colombia-Cundinamarca-Gachancipa,municipality,Colombia,Cundinamarca,Gachancipa,NA,CUNDINAMARCA,GACHANCIPA
-Colombia-Cundinamarca-Gacheta,municipality,Colombia,Cundinamarca,Gacheta,NA,CUNDINAMARCA,GACHETA
-Colombia-Cundinamarca-Gama,municipality,Colombia,Cundinamarca,Gama,NA,CUNDINAMARCA,GAMA
-Colombia-Cundinamarca-Girardot,municipality,Colombia,Cundinamarca,Girardot,NA,CUNDINAMARCA,GIRARDOT
-Colombia-Cundinamarca-Granada,municipality,Colombia,Cundinamarca,Granada,NA,CUNDINAMARCA,GRANADA
-Colombia-Cundinamarca-Guacheta,municipality,Colombia,Cundinamarca,Guacheta,NA,CUNDINAMARCA,GUACHETA
-Colombia-Cundinamarca-Guaduas,municipality,Colombia,Cundinamarca,Guaduas,NA,CUNDINAMARCA,GUADUAS
-Colombia-Cundinamarca-Guasca,municipality,Colombia,Cundinamarca,Guasca,NA,CUNDINAMARCA,GUASCA
-Colombia-Cundinamarca-Guataqui,municipality,Colombia,Cundinamarca,Guataqui,NA,CUNDINAMARCA,GUATAQUI
-Colombia-Cundinamarca-Guatavita,municipality,Colombia,Cundinamarca,Guatavita,NA,CUNDINAMARCA,GUATAVITA
-Colombia-Cundinamarca-Guayabal_De_Siquima,municipality,Colombia,Cundinamarca,Guayabal_De_Siquima,NA,CUNDINAMARCA,GUAYABAL DE SIQUIMA
-Colombia-Cundinamarca-Guayabetal,municipality,Colombia,Cundinamarca,Guayabetal,NA,CUNDINAMARCA,GUAYABETAL
-Colombia-Cundinamarca-Gutierrez,municipality,Colombia,Cundinamarca,Gutierrez,NA,CUNDINAMARCA,GUTIERREZ
-Colombia-Cundinamarca-Jerusalen,municipality,Colombia,Cundinamarca,Jerusalen,NA,CUNDINAMARCA,JERUSALEN
-Colombia-Cundinamarca-Junin,municipality,Colombia,Cundinamarca,Junin,NA,CUNDINAMARCA,JUNIN
-Colombia-Cundinamarca-La_Calera,municipality,Colombia,Cundinamarca,La_Calera,NA,CUNDINAMARCA,LA CALERA
-Colombia-Cundinamarca-La_Mesa,municipality,Colombia,Cundinamarca,La_Mesa,NA,CUNDINAMARCA,LA MESA
-Colombia-Cundinamarca-La_Palma,municipality,Colombia,Cundinamarca,La_Palma,NA,CUNDINAMARCA,LA PALMA
-Colombia-Cundinamarca-La_Pena,municipality,Colombia,Cundinamarca,La_Pena,NA,CUNDINAMARCA,LA PEÑA
-Colombia-Cundinamarca-La_Vega,municipality,Colombia,Cundinamarca,La_Vega,NA,CUNDINAMARCA,LA VEGA
-Colombia-Cundinamarca-Lenguazaque,municipality,Colombia,Cundinamarca,Lenguazaque,NA,CUNDINAMARCA,LENGUAZAQUE
-Colombia-Cundinamarca-Macheta,municipality,Colombia,Cundinamarca,Macheta,NA,CUNDINAMARCA,MACHETA
-Colombia-Cundinamarca-Madrid,municipality,Colombia,Cundinamarca,Madrid,NA,CUNDINAMARCA,MADRID
-Colombia-Cundinamarca-Manta,municipality,Colombia,Cundinamarca,Manta,NA,CUNDINAMARCA,MANTA
-Colombia-Cundinamarca-Medina,municipality,Colombia,Cundinamarca,Medina,NA,CUNDINAMARCA,MEDINA
-Colombia-Cundinamarca-Mosquera,municipality,Colombia,Cundinamarca,Mosquera,NA,CUNDINAMARCA,MOSQUERA
-Colombia-Cundinamarca-Narino,municipality,Colombia,Cundinamarca,Narino,NA,CUNDINAMARCA,NARIÑO
-Colombia-Cundinamarca-Nemocon,municipality,Colombia,Cundinamarca,Nemocon,NA,CUNDINAMARCA,NEMOCON
-Colombia-Cundinamarca-Nilo,municipality,Colombia,Cundinamarca,Nilo,NA,CUNDINAMARCA,NILO
-Colombia-Cundinamarca-Nimaima,municipality,Colombia,Cundinamarca,Nimaima,NA,CUNDINAMARCA,NIMAIMA
-Colombia-Cundinamarca-Nocaima,municipality,Colombia,Cundinamarca,Nocaima,NA,CUNDINAMARCA,NOCAIMA
-Colombia-Cundinamarca-Venecia,municipality,Colombia,Cundinamarca,Venecia,NA,CUNDINAMARCA,VENECIA
-Colombia-Cundinamarca-Pacho,municipality,Colombia,Cundinamarca,Pacho,NA,CUNDINAMARCA,PACHO
-Colombia-Cundinamarca-Paime,municipality,Colombia,Cundinamarca,Paime,NA,CUNDINAMARCA,PAIME
-Colombia-Cundinamarca-Pandi,municipality,Colombia,Cundinamarca,Pandi,NA,CUNDINAMARCA,PANDI
-Colombia-Cundinamarca-Paratebueno,municipality,Colombia,Cundinamarca,Paratebueno,NA,CUNDINAMARCA,PARATEBUENO
-Colombia-Cundinamarca-Pasca,municipality,Colombia,Cundinamarca,Pasca,NA,CUNDINAMARCA,PASCA
-Colombia-Cundinamarca-Puerto_Salgar,municipality,Colombia,Cundinamarca,Puerto_Salgar,NA,CUNDINAMARCA,PUERTO SALGAR
-Colombia-Cundinamarca-Puli,municipality,Colombia,Cundinamarca,Puli,NA,CUNDINAMARCA,PULI
-Colombia-Cundinamarca-Quebradanegra,municipality,Colombia,Cundinamarca,Quebradanegra,NA,CUNDINAMARCA,QUEBRADANEGRA
-Colombia-Cundinamarca-Quetame,municipality,Colombia,Cundinamarca,Quetame,NA,CUNDINAMARCA,QUETAME
-Colombia-Cundinamarca-Quipile,municipality,Colombia,Cundinamarca,Quipile,NA,CUNDINAMARCA,QUIPILE
-Colombia-Cundinamarca-Apulo,municipality,Colombia,Cundinamarca,Apulo,NA,CUNDINAMARCA,APULO
-Colombia-Cundinamarca-Rafael_Reyes_(Apulo),municipality,Colombia,Cundinamarca,Rafael_Reyes_(Apulo),NA,CUNDINAMARCA,Rafael_Reyes_(Apulo)
-Colombia-Cundinamarca-Ricaurte,municipality,Colombia,Cundinamarca,Ricaurte,NA,CUNDINAMARCA,RICAURTE
-Colombia-Cundinamarca-San_Antonio_Del_Tequendama,municipality,Colombia,Cundinamarca,San_Antonio_Del_Tequendama,NA,CUNDINAMARCA,SAN ANTONIO DEL TEQUENDAMA
-Colombia-Cundinamarca-San_Bernardo,municipality,Colombia,Cundinamarca,San_Bernardo,NA,CUNDINAMARCA,SAN BERNARDO
-Colombia-Cundinamarca-San_Cayetano,municipality,Colombia,Cundinamarca,San_Cayetano,NA,CUNDINAMARCA,SAN CAYETANO
-Colombia-Cundinamarca-San_Francisco,municipality,Colombia,Cundinamarca,San_Francisco,NA,CUNDINAMARCA,SAN FRANCISCO
-Colombia-Cundinamarca-San_Juan_De_Rio_Seco,municipality,Colombia,Cundinamarca,San_Juan_De_Rio_Seco,NA,CUNDINAMARCA,SAN JUAN DE RIO SECO
-Colombia-Cundinamarca-Sasaima,municipality,Colombia,Cundinamarca,Sasaima,NA,CUNDINAMARCA,SASAIMA
-Colombia-Cundinamarca-Sesquile,municipality,Colombia,Cundinamarca,Sesquile,NA,CUNDINAMARCA,SESQUILE
-Colombia-Cundinamarca-Sibate,municipality,Colombia,Cundinamarca,Sibate,NA,CUNDINAMARCA,SIBATE
-Colombia-Cundinamarca-Silvania,municipality,Colombia,Cundinamarca,Silvania,NA,CUNDINAMARCA,SILVANIA
-Colombia-Cundinamarca-Simijaca,municipality,Colombia,Cundinamarca,Simijaca,NA,CUNDINAMARCA,SIMIJACA
-Colombia-Cundinamarca-Soacha,municipality,Colombia,Cundinamarca,Soacha,NA,CUNDINAMARCA,SOACHA
-Colombia-Cundinamarca-Sopo,municipality,Colombia,Cundinamarca,Sopo,NA,CUNDINAMARCA,SOPO
-Colombia-Cundinamarca-Subachoque,municipality,Colombia,Cundinamarca,Subachoque,NA,CUNDINAMARCA,SUBACHOQUE
-Colombia-Cundinamarca-Suesca,municipality,Colombia,Cundinamarca,Suesca,NA,CUNDINAMARCA,SUESCA
-Colombia-Cundinamarca-Supata,municipality,Colombia,Cundinamarca,Supata,NA,CUNDINAMARCA,SUPATA
-Colombia-Cundinamarca-Susa,municipality,Colombia,Cundinamarca,Susa,NA,CUNDINAMARCA,SUSA
-Colombia-Cundinamarca-Sutatausa,municipality,Colombia,Cundinamarca,Sutatausa,NA,CUNDINAMARCA,SUTATAUSA
-Colombia-Cundinamarca-Tabio,municipality,Colombia,Cundinamarca,Tabio,NA,CUNDINAMARCA,TABIO
-Colombia-Cundinamarca-Tausa,municipality,Colombia,Cundinamarca,Tausa,NA,CUNDINAMARCA,TAUSA
-Colombia-Cundinamarca-Tena,municipality,Colombia,Cundinamarca,Tena,NA,CUNDINAMARCA,TENA
-Colombia-Cundinamarca-Tenjo,municipality,Colombia,Cundinamarca,Tenjo,NA,CUNDINAMARCA,TENJO
-Colombia-Cundinamarca-Tibacuy,municipality,Colombia,Cundinamarca,Tibacuy,NA,CUNDINAMARCA,TIBACUY
-Colombia-Cundinamarca-Tibirita,municipality,Colombia,Cundinamarca,Tibirita,NA,CUNDINAMARCA,TIBIRITA
-Colombia-Cundinamarca-Tocaima,municipality,Colombia,Cundinamarca,Tocaima,NA,CUNDINAMARCA,TOCAIMA
-Colombia-Cundinamarca-Tocancipa,municipality,Colombia,Cundinamarca,Tocancipa,NA,CUNDINAMARCA,TOCANCIPA
-Colombia-Cundinamarca-Topaipi,municipality,Colombia,Cundinamarca,Topaipi,NA,CUNDINAMARCA,TOPAIPI
-Colombia-Cundinamarca-Ubala,municipality,Colombia,Cundinamarca,Ubala,NA,CUNDINAMARCA,UBALA
-Colombia-Cundinamarca-Ubaque,municipality,Colombia,Cundinamarca,Ubaque,NA,CUNDINAMARCA,UBAQUE
-Colombia-Cundinamarca-Villa_De_San_Diego_De_Ubate,municipality,Colombia,Cundinamarca,Villa_De_San_Diego_De_Ubate,NA,CUNDINAMARCA,VILLA DE SAN DIEGO DE UBATE
-Colombia-Cundinamarca-Une,municipality,Colombia,Cundinamarca,Une,NA,CUNDINAMARCA,UNE
-Colombia-Cundinamarca-Utica,municipality,Colombia,Cundinamarca,Utica,NA,CUNDINAMARCA,UTICA
-Colombia-Cundinamarca-Vergara,municipality,Colombia,Cundinamarca,Vergara,NA,CUNDINAMARCA,VERGARA
-Colombia-Cundinamarca-Viani,municipality,Colombia,Cundinamarca,Viani,NA,CUNDINAMARCA,VIANI
-Colombia-Cundinamarca-Villagomez,municipality,Colombia,Cundinamarca,Villagomez,NA,CUNDINAMARCA,VILLAGOMEZ
-Colombia-Cundinamarca-Villapinzon,municipality,Colombia,Cundinamarca,Villapinzon,NA,CUNDINAMARCA,VILLAPINZON
-Colombia-Cundinamarca-Villeta,municipality,Colombia,Cundinamarca,Villeta,NA,CUNDINAMARCA,VILLETA
-Colombia-Cundinamarca-Viota,municipality,Colombia,Cundinamarca,Viota,NA,CUNDINAMARCA,VIOTA
-Colombia-Cundinamarca-Yacopi,municipality,Colombia,Cundinamarca,Yacopi,NA,CUNDINAMARCA,YACOPI
-Colombia-Cundinamarca-Zipacon,municipality,Colombia,Cundinamarca,Zipacon,NA,CUNDINAMARCA,ZIPACON
-Colombia-Cundinamarca-Zipaquira,municipality,Colombia,Cundinamarca,Zipaquira,NA,CUNDINAMARCA,ZIPAQUIRA
-Colombia-Choco-Unknown,municipality,Colombia,Choco,Unknown,NA,CHOCO,* CHOCO. MUNICIPIO DESCONOCIDO
-Colombia-Choco-Quibdo,municipality,Colombia,Choco,Quibdo,NA,CHOCO,QUIBDO
-Colombia-Choco-Acandi,municipality,Colombia,Choco,Acandi,NA,CHOCO,ACANDI
-Colombia-Choco-Alto_Baudo,municipality,Colombia,Choco,Alto_Baudo,NA,CHOCO,ALTO BAUDO
-Colombia-Choco-Atrato,municipality,Colombia,Choco,Atrato,NA,CHOCO,ATRATO
-Colombia-Choco-Bagado,municipality,Colombia,Choco,Bagado,NA,CHOCO,BAGADO
-Colombia-Choco-Bahia_Solano,municipality,Colombia,Choco,Bahia_Solano,NA,CHOCO,BAHIA SOLANO
-Colombia-Choco-Bajo_Baudo,municipality,Colombia,Choco,Bajo_Baudo,NA,CHOCO,BAJO BAUDO
-Colombia-Choco-Belen_De_Bajira,municipality,Colombia,Choco,Belen_De_Bajira,NA,CHOCO,BELEN DE BAJIRA
-Colombia-Choco-Bojaya,municipality,Colombia,Choco,Bojaya,NA,CHOCO,BOJAYA
-Colombia-Choco-El_Canton_Del_San_Pablo,municipality,Colombia,Choco,El_Canton_Del_San_Pablo,NA,CHOCO,EL CANTON DEL SAN PABLO
-Colombia-Choco-Carmen_Del_Darien,municipality,Colombia,Choco,Carmen_Del_Darien,NA,CHOCO,CARMEN DEL DARIEN
-Colombia-Choco-Certegui,municipality,Colombia,Choco,Certegui,NA,CHOCO,CERTEGUI
-Colombia-Choco-Condoto,municipality,Colombia,Choco,Condoto,NA,CHOCO,CONDOTO
-Colombia-Choco-El_Carmen_De_Atrato,municipality,Colombia,Choco,El_Carmen_De_Atrato,NA,CHOCO,EL CARMEN DE ATRATO
-Colombia-Choco-El_Litoral_Del_San_Juan,municipality,Colombia,Choco,El_Litoral_Del_San_Juan,NA,CHOCO,EL LITORAL DEL SAN JUAN
-Colombia-Choco-Istmina,municipality,Colombia,Choco,Istmina,NA,CHOCO,ISTMINA
-Colombia-Choco-Jurado,municipality,Colombia,Choco,Jurado,NA,CHOCO,JURADO
-Colombia-Choco-Lloro,municipality,Colombia,Choco,Lloro,NA,CHOCO,LLORO
-Colombia-Choco-Medio_Atrato,municipality,Colombia,Choco,Medio_Atrato,NA,CHOCO,MEDIO ATRATO
-Colombia-Choco-Medio_Baudo,municipality,Colombia,Choco,Medio_Baudo,NA,CHOCO,MEDIO BAUDO
-Colombia-Choco-Medio_San_Juan,municipality,Colombia,Choco,Medio_San_Juan,NA,CHOCO,MEDIO SAN JUAN
-Colombia-Choco-Novita,municipality,Colombia,Choco,Novita,NA,CHOCO,NOVITA
-Colombia-Choco-Nuqui,municipality,Colombia,Choco,Nuqui,NA,CHOCO,NUQUI
-Colombia-Choco-Rio_Iro,municipality,Colombia,Choco,Rio_Iro,NA,CHOCO,RIO IRO
-Colombia-Choco-Rio_Quito,municipality,Colombia,Choco,Rio_Quito,NA,CHOCO,RIO QUITO
-Colombia-Choco-Riosucio,municipality,Colombia,Choco,Riosucio,NA,CHOCO,RIOSUCIO
-Colombia-Choco-San_Jose_Del_Palmar,municipality,Colombia,Choco,San_Jose_Del_Palmar,NA,CHOCO,SAN JOSE DEL PALMAR
-Colombia-Choco-Sipi,municipality,Colombia,Choco,Sipi,NA,CHOCO,SIPI
-Colombia-Choco-Tado,municipality,Colombia,Choco,Tado,NA,CHOCO,TADO
-Colombia-Choco-Unguia,municipality,Colombia,Choco,Unguia,NA,CHOCO,UNGUIA
-Colombia-Choco-Union_Panamericana,municipality,Colombia,Choco,Union_Panamericana,NA,CHOCO,UNION PANAMERICANA
-Colombia-Huila-Unknown,municipality,Colombia,Huila,Unknown,NA,HUILA,* HUILA. MUNICIPIO DESCONOCIDO
-Colombia-Huila-Neiva,municipality,Colombia,Huila,Neiva,NA,HUILA,NEIVA
-Colombia-Huila-Acevedo,municipality,Colombia,Huila,Acevedo,NA,HUILA,ACEVEDO
-Colombia-Huila-Agrado,municipality,Colombia,Huila,Agrado,NA,HUILA,AGRADO
-Colombia-Huila-Aipe,municipality,Colombia,Huila,Aipe,NA,HUILA,AIPE
-Colombia-Huila-Algeciras,municipality,Colombia,Huila,Algeciras,NA,HUILA,ALGECIRAS
-Colombia-Huila-Altamira,municipality,Colombia,Huila,Altamira,NA,HUILA,ALTAMIRA
-Colombia-Huila-Baraya,municipality,Colombia,Huila,Baraya,NA,HUILA,BARAYA
-Colombia-Huila-Campoalegre,municipality,Colombia,Huila,Campoalegre,NA,HUILA,CAMPOALEGRE
-Colombia-Huila-Colombia,municipality,Colombia,Huila,Colombia,NA,HUILA,COLOMBIA
-Colombia-Huila-Elias,municipality,Colombia,Huila,Elias,NA,HUILA,ELIAS
-Colombia-Huila-Garzon,municipality,Colombia,Huila,Garzon,NA,HUILA,GARZON
-Colombia-Huila-Gigante,municipality,Colombia,Huila,Gigante,NA,HUILA,GIGANTE
-Colombia-Huila-Guadalupe,municipality,Colombia,Huila,Guadalupe,NA,HUILA,GUADALUPE
-Colombia-Huila-Hobo,municipality,Colombia,Huila,Hobo,NA,HUILA,HOBO
-Colombia-Huila-Iquira,municipality,Colombia,Huila,Iquira,NA,HUILA,IQUIRA
-Colombia-Huila-Isnos,municipality,Colombia,Huila,Isnos,NA,HUILA,ISNOS
-Colombia-Huila-La_Argentina,municipality,Colombia,Huila,La_Argentina,NA,HUILA,LA ARGENTINA
-Colombia-Huila-La_Plata,municipality,Colombia,Huila,La_Plata,NA,HUILA,LA PLATA
-Colombia-Huila-Nataga,municipality,Colombia,Huila,Nataga,NA,HUILA,NATAGA
-Colombia-Huila-Oporapa,municipality,Colombia,Huila,Oporapa,NA,HUILA,OPORAPA
-Colombia-Huila-Paicol,municipality,Colombia,Huila,Paicol,NA,HUILA,PAICOL
-Colombia-Huila-Palermo,municipality,Colombia,Huila,Palermo,NA,HUILA,PALERMO
-Colombia-Huila-Palestina,municipality,Colombia,Huila,Palestina,NA,HUILA,PALESTINA
-Colombia-Huila-Pital,municipality,Colombia,Huila,Pital,NA,HUILA,PITAL
-Colombia-Huila-Pitalito,municipality,Colombia,Huila,Pitalito,NA,HUILA,PITALITO
-Colombia-Huila-Rivera,municipality,Colombia,Huila,Rivera,NA,HUILA,RIVERA
-Colombia-Huila-Saladoblanco,municipality,Colombia,Huila,Saladoblanco,NA,HUILA,SALADOBLANCO
-Colombia-Huila-San_Agustin,municipality,Colombia,Huila,San_Agustin,NA,HUILA,SAN AGUSTIN
-Colombia-Huila-Santa_Maria,municipality,Colombia,Huila,Santa_Maria,NA,HUILA,SANTA MARIA
-Colombia-Huila-Suaza,municipality,Colombia,Huila,Suaza,NA,HUILA,SUAZA
-Colombia-Huila-Tarqui,municipality,Colombia,Huila,Tarqui,NA,HUILA,TARQUI
-Colombia-Huila-Tesalia,municipality,Colombia,Huila,Tesalia,NA,HUILA,TESALIA
-Colombia-Huila-Tello,municipality,Colombia,Huila,Tello,NA,HUILA,TELLO
-Colombia-Huila-Teruel,municipality,Colombia,Huila,Teruel,NA,HUILA,TERUEL
-Colombia-Huila-Timana,municipality,Colombia,Huila,Timana,NA,HUILA,TIMANA
-Colombia-Huila-Villavieja,municipality,Colombia,Huila,Villavieja,NA,HUILA,VILLAVIEJA
-Colombia-Huila-Yaguara,municipality,Colombia,Huila,Yaguara,NA,HUILA,YAGUARA
-Colombia-Guajira-Unknown,municipality,Colombia,Guajira,Unknown,NA,GUAJIRA,* LA GUAJIRA. MUNICIPIO DESCONOCIDO
-Colombia-Guajira-Riohacha,municipality,Colombia,Guajira,Riohacha,NA,GUAJIRA,RIOHACHA
-Colombia-Guajira-Albania,municipality,Colombia,Guajira,Albania,NA,GUAJIRA,ALBANIA
-Colombia-Guajira-Barrancas,municipality,Colombia,Guajira,Barrancas,NA,GUAJIRA,BARRANCAS
-Colombia-Guajira-Dibulla,municipality,Colombia,Guajira,Dibulla,NA,GUAJIRA,DIBULLA
-Colombia-Guajira-Distraccion,municipality,Colombia,Guajira,Distraccion,NA,GUAJIRA,DISTRACCION
-Colombia-Guajira-El_Molino,municipality,Colombia,Guajira,El_Molino,NA,GUAJIRA,EL MOLINO
-Colombia-Guajira-Fonseca,municipality,Colombia,Guajira,Fonseca,NA,GUAJIRA,FONSECA
-Colombia-Guajira-Hatonuevo,municipality,Colombia,Guajira,Hatonuevo,NA,GUAJIRA,HATONUEVO
-Colombia-Guajira-La_Jagua_Del_Pilar,municipality,Colombia,Guajira,La_Jagua_Del_Pilar,NA,GUAJIRA,LA JAGUA DEL PILAR
-Colombia-Guajira-Maicao,municipality,Colombia,Guajira,Maicao,NA,GUAJIRA,MAICAO
-Colombia-Guajira-Manaure,municipality,Colombia,Guajira,Manaure,NA,GUAJIRA,MANAURE
-Colombia-Guajira-San_Juan_Del_Cesar,municipality,Colombia,Guajira,San_Juan_Del_Cesar,NA,GUAJIRA,SAN JUAN DEL CESAR
-Colombia-Guajira-Uribia,municipality,Colombia,Guajira,Uribia,NA,GUAJIRA,URIBIA
-Colombia-Guajira-Urumita,municipality,Colombia,Guajira,Urumita,NA,GUAJIRA,URUMITA
-Colombia-Guajira-Villanueva,municipality,Colombia,Guajira,Villanueva,NA,GUAJIRA,VILLANUEVA
-Colombia-Sta_Marta_D.E.-Santa_Marta,municipality,Colombia,Sta_Marta_D.E.,Santa_Marta,NA,STA MARTA D.E.,SANTA MARTA
-Colombia-Magdalena-Unknown,municipality,Colombia,Magdalena,Unknown,NA,MAGDALENA,* MAGDALENA. MUNICIPIO DESCONOCIDO
-Colombia-Magdalena-Sitio_Nuevo,municipality,Colombia,Magdalena,Sitio_Nuevo,NA,MAGDALENA,* MAGDALENA. MUNICIPIO DESCONOCIDO
-Colombia-Magdalena-Algarrobo,municipality,Colombia,Magdalena,Algarrobo,NA,MAGDALENA,ALGARROBO
-Colombia-Magdalena-Aracataca,municipality,Colombia,Magdalena,Aracataca,NA,MAGDALENA,ARACATACA
-Colombia-Magdalena-Ariguani,municipality,Colombia,Magdalena,Ariguani,NA,MAGDALENA,ARIGUANI
-Colombia-Magdalena-Cerro_San_Antonio,municipality,Colombia,Magdalena,Cerro_San_Antonio,NA,MAGDALENA,CERRO SAN ANTONIO
-Colombia-Magdalena-Chibolo,municipality,Colombia,Magdalena,Chibolo,NA,MAGDALENA,CHIBOLO
-Colombia-Magdalena-Cienaga,municipality,Colombia,Magdalena,Cienaga,NA,MAGDALENA,CIENAGA
-Colombia-Magdalena-Concordia,municipality,Colombia,Magdalena,Concordia,NA,MAGDALENA,CONCORDIA
-Colombia-Magdalena-El_Banco,municipality,Colombia,Magdalena,El_Banco,NA,MAGDALENA,EL BANCO
-Colombia-Magdalena-El_Pinon,municipality,Colombia,Magdalena,El_Pinon,NA,MAGDALENA,EL PIÑON
-Colombia-Magdalena-El_Reten,municipality,Colombia,Magdalena,El_Reten,NA,MAGDALENA,EL RETEN
-Colombia-Magdalena-Fundacion,municipality,Colombia,Magdalena,Fundacion,NA,MAGDALENA,FUNDACION
-Colombia-Magdalena-Guamal,municipality,Colombia,Magdalena,Guamal,NA,MAGDALENA,GUAMAL
-Colombia-Magdalena-Nueva_Granada,municipality,Colombia,Magdalena,Nueva_Granada,NA,MAGDALENA,NUEVA GRANADA
-Colombia-Magdalena-Pedraza,municipality,Colombia,Magdalena,Pedraza,NA,MAGDALENA,PEDRAZA
-Colombia-Magdalena-Pijino_Del_Carmen,municipality,Colombia,Magdalena,Pijino_Del_Carmen,NA,MAGDALENA,PIJIÑO DEL CARMEN
-Colombia-Magdalena-Pivijay,municipality,Colombia,Magdalena,Pivijay,NA,MAGDALENA,PIVIJAY
-Colombia-Magdalena-Plato,municipality,Colombia,Magdalena,Plato,NA,MAGDALENA,PLATO
-Colombia-Magdalena-Puebloviejo,municipality,Colombia,Magdalena,Puebloviejo,NA,MAGDALENA,PUEBLOVIEJO
-Colombia-Magdalena-Remolino,municipality,Colombia,Magdalena,Remolino,NA,MAGDALENA,REMOLINO
-Colombia-Magdalena-Sabanas_De_San_Angel,municipality,Colombia,Magdalena,Sabanas_De_San_Angel,NA,MAGDALENA,SABANAS DE SAN ANGEL
-Colombia-Magdalena-Salamina,municipality,Colombia,Magdalena,Salamina,NA,MAGDALENA,SALAMINA
-Colombia-Magdalena-San_Sebastian_De_Buenavista,municipality,Colombia,Magdalena,San_Sebastian_De_Buenavista,NA,MAGDALENA,SAN SEBASTIAN DE BUENAVISTA
-Colombia-Magdalena-San_Zenon,municipality,Colombia,Magdalena,San_Zenon,NA,MAGDALENA,SAN ZENON
-Colombia-Magdalena-Santa_Ana,municipality,Colombia,Magdalena,Santa_Ana,NA,MAGDALENA,SANTA ANA
-Colombia-Magdalena-Santa_Barbara_De_Pinto,municipality,Colombia,Magdalena,Santa_Barbara_De_Pinto,NA,MAGDALENA,SANTA BARBARA DE PINTO
-Colombia-Magdalena-Sitionuevo,municipality,Colombia,Magdalena,Sitionuevo,NA,MAGDALENA,SITIONUEVO
-Colombia-Magdalena-Tenerife,municipality,Colombia,Magdalena,Tenerife,NA,MAGDALENA,TENERIFE
-Colombia-Magdalena-Zapayan,municipality,Colombia,Magdalena,Zapayan,NA,MAGDALENA,ZAPAYAN
-Colombia-Magdalena-Zona_Bananera,municipality,Colombia,Magdalena,Zona_Bananera,NA,MAGDALENA,ZONA BANANERA
-Colombia-Meta-Unknown,municipality,Colombia,Meta,Unknown,NA,META,* META. MUNICIPIO DESCONOCIDO
-Colombia-Meta-Villavicencio,municipality,Colombia,Meta,Villavicencio,NA,META,VILLAVICENCIO
-Colombia-Meta-Acacias,municipality,Colombia,Meta,Acacias,NA,META,ACACIAS
-Colombia-Meta-Barranca_De_Upia,municipality,Colombia,Meta,Barranca_De_Upia,NA,META,BARRANCA DE UPIA
-Colombia-Meta-Cabuyaro,municipality,Colombia,Meta,Cabuyaro,NA,META,CABUYARO
-Colombia-Meta-Castilla_La_Nueva,municipality,Colombia,Meta,Castilla_La_Nueva,NA,META,CASTILLA LA NUEVA
-Colombia-Meta-Cubarral,municipality,Colombia,Meta,Cubarral,NA,META,CUBARRAL
-Colombia-Meta-Cumaral,municipality,Colombia,Meta,Cumaral,NA,META,CUMARAL
-Colombia-Meta-El_Calvario,municipality,Colombia,Meta,El_Calvario,NA,META,EL CALVARIO
-Colombia-Meta-El_Castillo,municipality,Colombia,Meta,El_Castillo,NA,META,EL CASTILLO
-Colombia-Meta-El_Dorado,municipality,Colombia,Meta,El_Dorado,NA,META,EL DORADO
-Colombia-Meta-Fuente_De_Oro,municipality,Colombia,Meta,Fuente_De_Oro,NA,META,FUENTE DE ORO
-Colombia-Meta-Granada,municipality,Colombia,Meta,Granada,NA,META,GRANADA
-Colombia-Meta-Guamal,municipality,Colombia,Meta,Guamal,NA,META,GUAMAL
-Colombia-Meta-Mapiripan,municipality,Colombia,Meta,Mapiripan,NA,META,MAPIRIPAN
-Colombia-Meta-Mesetas,municipality,Colombia,Meta,Mesetas,NA,META,MESETAS
-Colombia-Meta-La_Macarena,municipality,Colombia,Meta,La_Macarena,NA,META,LA MACARENA
-Colombia-Meta-Uribe,municipality,Colombia,Meta,Uribe,NA,META,URIBE
-Colombia-Meta-Lejanias,municipality,Colombia,Meta,Lejanias,NA,META,LEJANIAS
-Colombia-Meta-Puerto_Concordia,municipality,Colombia,Meta,Puerto_Concordia,NA,META,PUERTO CONCORDIA
-Colombia-Meta-Puerto_Gaitan,municipality,Colombia,Meta,Puerto_Gaitan,NA,META,PUERTO GAITAN
-Colombia-Meta-Puerto_Lopez,municipality,Colombia,Meta,Puerto_Lopez,NA,META,PUERTO LOPEZ
-Colombia-Meta-Puerto_Lleras,municipality,Colombia,Meta,Puerto_Lleras,NA,META,PUERTO LLERAS
-Colombia-Meta-Puerto_Rico,municipality,Colombia,Meta,Puerto_Rico,NA,META,PUERTO RICO
-Colombia-Meta-Restrepo,municipality,Colombia,Meta,Restrepo,NA,META,RESTREPO
-Colombia-Meta-San_Carlos_De_Guaroa,municipality,Colombia,Meta,San_Carlos_De_Guaroa,NA,META,SAN CARLOS DE GUAROA
-Colombia-Meta-San_Juan_De_Arama,municipality,Colombia,Meta,San_Juan_De_Arama,NA,META,SAN JUAN DE ARAMA
-Colombia-Meta-San_Juanito,municipality,Colombia,Meta,San_Juanito,NA,META,SAN JUANITO
-Colombia-Meta-San_Martin,municipality,Colombia,Meta,San_Martin,NA,META,SAN MARTIN
-Colombia-Meta-Vistahermosa,municipality,Colombia,Meta,Vistahermosa,NA,META,VISTAHERMOSA
-Colombia-Narino-Unknown,municipality,Colombia,Narino,Unknown,NA,NARIÑO,* NARIÑO. MUNICIPIO DESCONOCIDO
-Colombia-Narino-Pasto,municipality,Colombia,Narino,Pasto,NA,NARIÑO,PASTO
-Colombia-Narino-Alban,municipality,Colombia,Narino,Alban,NA,NARIÑO,ALBAN
-Colombia-Narino-Aldana,municipality,Colombia,Narino,Aldana,NA,NARIÑO,ALDANA
-Colombia-Narino-Ancuya,municipality,Colombia,Narino,Ancuya,NA,NARIÑO,ANCUYA
-Colombia-Narino-Arboleda,municipality,Colombia,Narino,Arboleda,NA,NARIÑO,ARBOLEDA
-Colombia-Narino-Barbacoas,municipality,Colombia,Narino,Barbacoas,NA,NARIÑO,BARBACOAS
-Colombia-Narino-Belen,municipality,Colombia,Narino,Belen,NA,NARIÑO,BELEN
-Colombia-Narino-Buesaco,municipality,Colombia,Narino,Buesaco,NA,NARIÑO,BUESACO
-Colombia-Narino-Colon,municipality,Colombia,Narino,Colon,NA,NARIÑO,COLON
-Colombia-Narino-Consaca,municipality,Colombia,Narino,Consaca,NA,NARIÑO,CONSACA
-Colombia-Narino-Contadero,municipality,Colombia,Narino,Contadero,NA,NARIÑO,CONTADERO
-Colombia-Narino-Cordoba,municipality,Colombia,Narino,Cordoba,NA,NARIÑO,CORDOBA
-Colombia-Narino-Cuaspud,municipality,Colombia,Narino,Cuaspud,NA,NARIÑO,CUASPUD
-Colombia-Narino-Cumbal,municipality,Colombia,Narino,Cumbal,NA,NARIÑO,CUMBAL
-Colombia-Narino-Cumbitara,municipality,Colombia,Narino,Cumbitara,NA,NARIÑO,CUMBITARA
-Colombia-Narino-Chachagui,municipality,Colombia,Narino,Chachagui,NA,NARIÑO,CHACHAGUI
-Colombia-Narino-El_Charco,municipality,Colombia,Narino,El_Charco,NA,NARIÑO,EL CHARCO
-Colombia-Narino-El_Penol,municipality,Colombia,Narino,El_Penol,NA,NARIÑO,EL PEÑOL
-Colombia-Narino-El_Rosario,municipality,Colombia,Narino,El_Rosario,NA,NARIÑO,EL ROSARIO
-Colombia-Narino-El_Tablon_De_Gomez,municipality,Colombia,Narino,El_Tablon_De_Gomez,NA,NARIÑO,EL TABLON DE GOMEZ
-Colombia-Narino-El_Tambo,municipality,Colombia,Narino,El_Tambo,NA,NARIÑO,EL TAMBO
-Colombia-Narino-Funes,municipality,Colombia,Narino,Funes,NA,NARIÑO,FUNES
-Colombia-Narino-Guachucal,municipality,Colombia,Narino,Guachucal,NA,NARIÑO,GUACHUCAL
-Colombia-Narino-Guaitarilla,municipality,Colombia,Narino,Guaitarilla,NA,NARIÑO,GUAITARILLA
-Colombia-Narino-Gualmatan,municipality,Colombia,Narino,Gualmatan,NA,NARIÑO,GUALMATAN
-Colombia-Narino-Iles,municipality,Colombia,Narino,Iles,NA,NARIÑO,ILES
-Colombia-Narino-Imues,municipality,Colombia,Narino,Imues,NA,NARIÑO,IMUES
-Colombia-Narino-Ipiales,municipality,Colombia,Narino,Ipiales,NA,NARIÑO,IPIALES
-Colombia-Narino-La_Cruz,municipality,Colombia,Narino,La_Cruz,NA,NARIÑO,LA CRUZ
-Colombia-Narino-La_Florida,municipality,Colombia,Narino,La_Florida,NA,NARIÑO,LA FLORIDA
-Colombia-Narino-La_Llanada,municipality,Colombia,Narino,La_Llanada,NA,NARIÑO,LA LLANADA
-Colombia-Narino-La_Tola,municipality,Colombia,Narino,La_Tola,NA,NARIÑO,LA TOLA
-Colombia-Narino-La_Union,municipality,Colombia,Narino,La_Union,NA,NARIÑO,LA UNION
-Colombia-Narino-Leiva,municipality,Colombia,Narino,Leiva,NA,NARIÑO,LEIVA
-Colombia-Narino-Linares,municipality,Colombia,Narino,Linares,NA,NARIÑO,LINARES
-Colombia-Narino-Los_Andes,municipality,Colombia,Narino,Los_Andes,NA,NARIÑO,LOS ANDES
-Colombia-Narino-Magsi,municipality,Colombia,Narino,Magsi,NA,NARIÑO,MAGSI
-Colombia-Narino-Mallama,municipality,Colombia,Narino,Mallama,NA,NARIÑO,MALLAMA
-Colombia-Narino-Mosquera,municipality,Colombia,Narino,Mosquera,NA,NARIÑO,MOSQUERA
-Colombia-Narino-Narino,municipality,Colombia,Narino,Narino,NA,NARIÑO,NARIÑO
-Colombia-Narino-Olaya_Herrera,municipality,Colombia,Narino,Olaya_Herrera,NA,NARIÑO,OLAYA HERRERA
-Colombia-Narino-Ospina,municipality,Colombia,Narino,Ospina,NA,NARIÑO,OSPINA
-Colombia-Narino-Francisco_Pizarro,municipality,Colombia,Narino,Francisco_Pizarro,NA,NARIÑO,FRANCISCO PIZARRO
-Colombia-Narino-Policarpa,municipality,Colombia,Narino,Policarpa,NA,NARIÑO,POLICARPA
-Colombia-Narino-Potosi,municipality,Colombia,Narino,Potosi,NA,NARIÑO,POTOSI
-Colombia-Narino-Providencia,municipality,Colombia,Narino,Providencia,NA,NARIÑO,PROVIDENCIA
-Colombia-Narino-Puerres,municipality,Colombia,Narino,Puerres,NA,NARIÑO,PUERRES
-Colombia-Narino-Pupiales,municipality,Colombia,Narino,Pupiales,NA,NARIÑO,PUPIALES
-Colombia-Narino-Ricaurte,municipality,Colombia,Narino,Ricaurte,NA,NARIÑO,RICAURTE
-Colombia-Narino-Roberto_Payan,municipality,Colombia,Narino,Roberto_Payan,NA,NARIÑO,ROBERTO PAYAN
-Colombia-Narino-Samaniego,municipality,Colombia,Narino,Samaniego,NA,NARIÑO,SAMANIEGO
-Colombia-Narino-Sandona,municipality,Colombia,Narino,Sandona,NA,NARIÑO,SANDONA
-Colombia-Narino-San_Bernardo,municipality,Colombia,Narino,San_Bernardo,NA,NARIÑO,SAN BERNARDO
-Colombia-Narino-San_Lorenzo,municipality,Colombia,Narino,San_Lorenzo,NA,NARIÑO,SAN LORENZO
-Colombia-Narino-San_Pablo,municipality,Colombia,Narino,San_Pablo,NA,NARIÑO,SAN PABLO
-Colombia-Narino-San_Pedro_De_Cartago,municipality,Colombia,Narino,San_Pedro_De_Cartago,NA,NARIÑO,SAN PEDRO DE CARTAGO
-Colombia-Narino-Santa_Barbara,municipality,Colombia,Narino,Santa_Barbara,NA,NARIÑO,SANTA BARBARA
-Colombia-Narino-Santacruz,municipality,Colombia,Narino,Santacruz,NA,NARIÑO,SANTACRUZ
-Colombia-Narino-Sapuyes,municipality,Colombia,Narino,Sapuyes,NA,NARIÑO,SAPUYES
-Colombia-Narino-Taminango,municipality,Colombia,Narino,Taminango,NA,NARIÑO,TAMINANGO
-Colombia-Narino-Tangua,municipality,Colombia,Narino,Tangua,NA,NARIÑO,TANGUA
-Colombia-Narino-San_Andres_De_Tumaco,municipality,Colombia,Narino,San_Andres_De_Tumaco,NA,NARIÑO,SAN ANDRES DE TUMACO
-Colombia-Narino-Tuquerres,municipality,Colombia,Narino,Tuquerres,NA,NARIÑO,TUQUERRES
-Colombia-Narino-Yacuanquer,municipality,Colombia,Narino,Yacuanquer,NA,NARIÑO,YACUANQUER
-Colombia-Norte_Santander-Unknown,municipality,Colombia,Norte_Santander,Unknown,NA,NORTE SANTANDER,* N. DE SANTANDER. MUNICIPIO DESCONOCIDO
-Colombia-Norte_Santander-Cucuta,municipality,Colombia,Norte_Santander,Cucuta,NA,NORTE SANTANDER,CUCUTA
-Colombia-Norte_Santander-Abrego,municipality,Colombia,Norte_Santander,Abrego,NA,NORTE SANTANDER,ABREGO
-Colombia-Norte_Santander-Arboledas,municipality,Colombia,Norte_Santander,Arboledas,NA,NORTE SANTANDER,ARBOLEDAS
-Colombia-Norte_Santander-Bochalema,municipality,Colombia,Norte_Santander,Bochalema,NA,NORTE SANTANDER,BOCHALEMA
-Colombia-Norte_Santander-Bucarasica,municipality,Colombia,Norte_Santander,Bucarasica,NA,NORTE SANTANDER,BUCARASICA
-Colombia-Norte_Santander-Cacota,municipality,Colombia,Norte_Santander,Cacota,NA,NORTE SANTANDER,CACOTA
-Colombia-Norte_Santander-Cachira,municipality,Colombia,Norte_Santander,Cachira,NA,NORTE SANTANDER,CACHIRA
-Colombia-Norte_Santander-Chinacota,municipality,Colombia,Norte_Santander,Chinacota,NA,NORTE SANTANDER,CHINACOTA
-Colombia-Norte_Santander-Chitaga,municipality,Colombia,Norte_Santander,Chitaga,NA,NORTE SANTANDER,CHITAGA
-Colombia-Norte_Santander-Convencion,municipality,Colombia,Norte_Santander,Convencion,NA,NORTE SANTANDER,CONVENCION
-Colombia-Norte_Santander-Cucutilla,municipality,Colombia,Norte_Santander,Cucutilla,NA,NORTE SANTANDER,CUCUTILLA
-Colombia-Norte_Santander-Durania,municipality,Colombia,Norte_Santander,Durania,NA,NORTE SANTANDER,DURANIA
-Colombia-Norte_Santander-El_Carmen,municipality,Colombia,Norte_Santander,El_Carmen,NA,NORTE SANTANDER,EL CARMEN
-Colombia-Norte_Santander-El_Tarra,municipality,Colombia,Norte_Santander,El_Tarra,NA,NORTE SANTANDER,EL TARRA
-Colombia-Norte_Santander-El_Zulia,municipality,Colombia,Norte_Santander,El_Zulia,NA,NORTE SANTANDER,EL ZULIA
-Colombia-Norte_Santander-Gramalote,municipality,Colombia,Norte_Santander,Gramalote,NA,NORTE SANTANDER,GRAMALOTE
-Colombia-Norte_Santander-Hacari,municipality,Colombia,Norte_Santander,Hacari,NA,NORTE SANTANDER,HACARI
-Colombia-Norte_Santander-Herran,municipality,Colombia,Norte_Santander,Herran,NA,NORTE SANTANDER,HERRAN
-Colombia-Norte_Santander-Labateca,municipality,Colombia,Norte_Santander,Labateca,NA,NORTE SANTANDER,LABATECA
-Colombia-Norte_Santander-La_Esperanza,municipality,Colombia,Norte_Santander,La_Esperanza,NA,NORTE SANTANDER,LA ESPERANZA
-Colombia-Norte_Santander-La_Playa,municipality,Colombia,Norte_Santander,La_Playa,NA,NORTE SANTANDER,LA PLAYA
-Colombia-Norte_Santander-Los_Patios,municipality,Colombia,Norte_Santander,Los_Patios,NA,NORTE SANTANDER,LOS PATIOS
-Colombia-Norte_Santander-Lourdes,municipality,Colombia,Norte_Santander,Lourdes,NA,NORTE SANTANDER,LOURDES
-Colombia-Norte_Santander-Mutiscua,municipality,Colombia,Norte_Santander,Mutiscua,NA,NORTE SANTANDER,MUTISCUA
-Colombia-Norte_Santander-Ocana,municipality,Colombia,Norte_Santander,Ocana,NA,NORTE SANTANDER,OCAÑA
-Colombia-Norte_Santander-Pamplona,municipality,Colombia,Norte_Santander,Pamplona,NA,NORTE SANTANDER,PAMPLONA
-Colombia-Norte_Santander-Pamplonita,municipality,Colombia,Norte_Santander,Pamplonita,NA,NORTE SANTANDER,PAMPLONITA
-Colombia-Norte_Santander-Puerto_Santander,municipality,Colombia,Norte_Santander,Puerto_Santander,NA,NORTE SANTANDER,PUERTO SANTANDER
-Colombia-Norte_Santander-Ragonvalia,municipality,Colombia,Norte_Santander,Ragonvalia,NA,NORTE SANTANDER,RAGONVALIA
-Colombia-Norte_Santander-Salazar,municipality,Colombia,Norte_Santander,Salazar,NA,NORTE SANTANDER,SALAZAR
-Colombia-Norte_Santander-San_Calixto,municipality,Colombia,Norte_Santander,San_Calixto,NA,NORTE SANTANDER,SAN CALIXTO
-Colombia-Norte_Santander-San_Cayetano,municipality,Colombia,Norte_Santander,San_Cayetano,NA,NORTE SANTANDER,SAN CAYETANO
-Colombia-Norte_Santander-Santiago,municipality,Colombia,Norte_Santander,Santiago,NA,NORTE SANTANDER,SANTIAGO
-Colombia-Norte_Santander-Sardinata,municipality,Colombia,Norte_Santander,Sardinata,NA,NORTE SANTANDER,SARDINATA
-Colombia-Norte_Santander-Silos,municipality,Colombia,Norte_Santander,Silos,NA,NORTE SANTANDER,SILOS
-Colombia-Norte_Santander-Teorama,municipality,Colombia,Norte_Santander,Teorama,NA,NORTE SANTANDER,TEORAMA
-Colombia-Norte_Santander-Tibu,municipality,Colombia,Norte_Santander,Tibu,NA,NORTE SANTANDER,TIBU
-Colombia-Norte_Santander-Toledo,municipality,Colombia,Norte_Santander,Toledo,NA,NORTE SANTANDER,TOLEDO
-Colombia-Norte_Santander-Villa_Caro,municipality,Colombia,Norte_Santander,Villa_Caro,NA,NORTE SANTANDER,VILLA CARO
-Colombia-Norte_Santander-Villa_Del_Rosario,municipality,Colombia,Norte_Santander,Villa_Del_Rosario,NA,NORTE SANTANDER,VILLA DEL ROSARIO
-Colombia-Quindio-Unknown,municipality,Colombia,Quindio,Unknown,NA,QUINDIO,* QUINDIO. MUNICIPIO DESCONOCIDO
-Colombia-Quindio-Armenia,municipality,Colombia,Quindio,Armenia,NA,QUINDIO,ARMENIA
-Colombia-Quindio-Buenavista,municipality,Colombia,Quindio,Buenavista,NA,QUINDIO,BUENAVISTA
-Colombia-Quindio-Calarca,municipality,Colombia,Quindio,Calarca,NA,QUINDIO,CALARCA
-Colombia-Quindio-Circasia,municipality,Colombia,Quindio,Circasia,NA,QUINDIO,CIRCASIA
-Colombia-Quindio-Cordoba,municipality,Colombia,Quindio,Cordoba,NA,QUINDIO,CORDOBA
-Colombia-Quindio-Filandia,municipality,Colombia,Quindio,Filandia,NA,QUINDIO,FILANDIA
-Colombia-Quindio-Genova,municipality,Colombia,Quindio,Genova,NA,QUINDIO,GENOVA
-Colombia-Quindio-La_Tebaida,municipality,Colombia,Quindio,La_Tebaida,NA,QUINDIO,LA TEBAIDA
-Colombia-Quindio-Montenegro,municipality,Colombia,Quindio,Montenegro,NA,QUINDIO,MONTENEGRO
-Colombia-Quindio-Pijao,municipality,Colombia,Quindio,Pijao,NA,QUINDIO,PIJAO
-Colombia-Quindio-Quimbaya,municipality,Colombia,Quindio,Quimbaya,NA,QUINDIO,QUIMBAYA
-Colombia-Quindio-Salento,municipality,Colombia,Quindio,Salento,NA,QUINDIO,SALENTO
-Colombia-Risaralda-Unknown,municipality,Colombia,Risaralda,Unknown,NA,RISARALDA,* RISARALDA. MUNICIPIO DESCONOCIDO
-Colombia-Risaralda-Pereira,municipality,Colombia,Risaralda,Pereira,NA,RISARALDA,PEREIRA
-Colombia-Risaralda-Apia,municipality,Colombia,Risaralda,Apia,NA,RISARALDA,APIA
-Colombia-Risaralda-Balboa,municipality,Colombia,Risaralda,Balboa,NA,RISARALDA,BALBOA
-Colombia-Risaralda-Belen_De_Umbria,municipality,Colombia,Risaralda,Belen_De_Umbria,NA,RISARALDA,BELEN DE UMBRIA
-Colombia-Risaralda-Dosquebradas,municipality,Colombia,Risaralda,Dosquebradas,NA,RISARALDA,DOSQUEBRADAS
-Colombia-Risaralda-Guatica,municipality,Colombia,Risaralda,Guatica,NA,RISARALDA,GUATICA
-Colombia-Risaralda-La_Celia,municipality,Colombia,Risaralda,La_Celia,NA,RISARALDA,LA CELIA
-Colombia-Risaralda-La_Virginia,municipality,Colombia,Risaralda,La_Virginia,NA,RISARALDA,LA VIRGINIA
-Colombia-Risaralda-Marsella,municipality,Colombia,Risaralda,Marsella,NA,RISARALDA,MARSELLA
-Colombia-Risaralda-Mistrato,municipality,Colombia,Risaralda,Mistrato,NA,RISARALDA,MISTRATO
-Colombia-Risaralda-Pueblo_Rico,municipality,Colombia,Risaralda,Pueblo_Rico,NA,RISARALDA,PUEBLO RICO
-Colombia-Risaralda-Quinchia,municipality,Colombia,Risaralda,Quinchia,NA,RISARALDA,QUINCHIA
-Colombia-Risaralda-Santa_Rosa_De_Cabal,municipality,Colombia,Risaralda,Santa_Rosa_De_Cabal,NA,RISARALDA,SANTA ROSA DE CABAL
-Colombia-Risaralda-Santuario,municipality,Colombia,Risaralda,Santuario,NA,RISARALDA,SANTUARIO
-Colombia-Santander-Unknown,municipality,Colombia,Santander,Unknown,NA,SANTANDER,* SANTANDER. MUNICIPIO DESCONOCIDO
-Colombia-Santander-Bucaramanga,municipality,Colombia,Santander,Bucaramanga,NA,SANTANDER,BUCARAMANGA
-Colombia-Santander-Aguada,municipality,Colombia,Santander,Aguada,NA,SANTANDER,AGUADA
-Colombia-Santander-Albania,municipality,Colombia,Santander,Albania,NA,SANTANDER,ALBANIA
-Colombia-Santander-Aratoca,municipality,Colombia,Santander,Aratoca,NA,SANTANDER,ARATOCA
-Colombia-Santander-Barbosa,municipality,Colombia,Santander,Barbosa,NA,SANTANDER,BARBOSA
-Colombia-Santander-Barichara,municipality,Colombia,Santander,Barichara,NA,SANTANDER,BARICHARA
-Colombia-Santander-Barrancabermeja,municipality,Colombia,Santander,Barrancabermeja,NA,SANTANDER,BARRANCABERMEJA
-Colombia-Santander-Betulia,municipality,Colombia,Santander,Betulia,NA,SANTANDER,BETULIA
-Colombia-Santander-Bolivar,municipality,Colombia,Santander,Bolivar,NA,SANTANDER,BOLIVAR
-Colombia-Santander-Cabrera,municipality,Colombia,Santander,Cabrera,NA,SANTANDER,CABRERA
-Colombia-Santander-California,municipality,Colombia,Santander,California,NA,SANTANDER,CALIFORNIA
-Colombia-Santander-Capitanejo,municipality,Colombia,Santander,Capitanejo,NA,SANTANDER,CAPITANEJO
-Colombia-Santander-Carcasi,municipality,Colombia,Santander,Carcasi,NA,SANTANDER,CARCASI
-Colombia-Santander-Cepita,municipality,Colombia,Santander,Cepita,NA,SANTANDER,CEPITA
-Colombia-Santander-Cerrito,municipality,Colombia,Santander,Cerrito,NA,SANTANDER,CERRITO
-Colombia-Santander-Charala,municipality,Colombia,Santander,Charala,NA,SANTANDER,CHARALA
-Colombia-Santander-Charta,municipality,Colombia,Santander,Charta,NA,SANTANDER,CHARTA
-Colombia-Santander-Chima,municipality,Colombia,Santander,Chima,NA,SANTANDER,CHIMA
-Colombia-Santander-Chipata,municipality,Colombia,Santander,Chipata,NA,SANTANDER,CHIPATA
-Colombia-Santander-Cimitarra,municipality,Colombia,Santander,Cimitarra,NA,SANTANDER,CIMITARRA
-Colombia-Santander-Concepcion,municipality,Colombia,Santander,Concepcion,NA,SANTANDER,CONCEPCION
-Colombia-Santander-Confines,municipality,Colombia,Santander,Confines,NA,SANTANDER,CONFINES
-Colombia-Santander-Contratacion,municipality,Colombia,Santander,Contratacion,NA,SANTANDER,CONTRATACION
-Colombia-Santander-Coromoro,municipality,Colombia,Santander,Coromoro,NA,SANTANDER,COROMORO
-Colombia-Santander-Curiti,municipality,Colombia,Santander,Curiti,NA,SANTANDER,CURITI
-Colombia-Santander-El_Carmen_De_Chucuri,municipality,Colombia,Santander,El_Carmen_De_Chucuri,NA,SANTANDER,EL CARMEN DE CHUCURI
-Colombia-Santander-El_Guacamayo,municipality,Colombia,Santander,El_Guacamayo,NA,SANTANDER,EL GUACAMAYO
-Colombia-Santander-El_Penon,municipality,Colombia,Santander,El_Penon,NA,SANTANDER,EL PEÑON
-Colombia-Santander-El_Playon,municipality,Colombia,Santander,El_Playon,NA,SANTANDER,EL PLAYON
-Colombia-Santander-Encino,municipality,Colombia,Santander,Encino,NA,SANTANDER,ENCINO
-Colombia-Santander-Enciso,municipality,Colombia,Santander,Enciso,NA,SANTANDER,ENCISO
-Colombia-Santander-Florian,municipality,Colombia,Santander,Florian,NA,SANTANDER,FLORIAN
-Colombia-Santander-Floridablanca,municipality,Colombia,Santander,Floridablanca,NA,SANTANDER,FLORIDABLANCA
-Colombia-Santander-Galan,municipality,Colombia,Santander,Galan,NA,SANTANDER,GALAN
-Colombia-Santander-Gambita,municipality,Colombia,Santander,Gambita,NA,SANTANDER,GAMBITA
-Colombia-Santander-Giron,municipality,Colombia,Santander,Giron,NA,SANTANDER,GIRON
-Colombia-Santander-Guaca,municipality,Colombia,Santander,Guaca,NA,SANTANDER,GUACA
-Colombia-Santander-Guadalupe,municipality,Colombia,Santander,Guadalupe,NA,SANTANDER,GUADALUPE
-Colombia-Santander-Guapota,municipality,Colombia,Santander,Guapota,NA,SANTANDER,GUAPOTA
-Colombia-Santander-Guavata,municipality,Colombia,Santander,Guavata,NA,SANTANDER,GUAVATA
-Colombia-Santander-Gsepsa,municipality,Colombia,Santander,Gsepsa,NA,SANTANDER,GSEPSA
-Colombia-Santander-Hato,municipality,Colombia,Santander,Hato,NA,SANTANDER,HATO
-Colombia-Santander-Jesus_Maria,municipality,Colombia,Santander,Jesus_Maria,NA,SANTANDER,JESUS MARIA
-Colombia-Santander-Jordan,municipality,Colombia,Santander,Jordan,NA,SANTANDER,JORDAN
-Colombia-Santander-La_Belleza,municipality,Colombia,Santander,La_Belleza,NA,SANTANDER,LA BELLEZA
-Colombia-Santander-Landazuri,municipality,Colombia,Santander,Landazuri,NA,SANTANDER,LANDAZURI
-Colombia-Santander-La_Paz,municipality,Colombia,Santander,La_Paz,NA,SANTANDER,LA PAZ
-Colombia-Santander-Lebrija,municipality,Colombia,Santander,Lebrija,NA,SANTANDER,LEBRIJA
-Colombia-Santander-Los_Santos,municipality,Colombia,Santander,Los_Santos,NA,SANTANDER,LOS SANTOS
-Colombia-Santander-Macaravita,municipality,Colombia,Santander,Macaravita,NA,SANTANDER,MACARAVITA
-Colombia-Santander-Malaga,municipality,Colombia,Santander,Malaga,NA,SANTANDER,MALAGA
-Colombia-Santander-Matanza,municipality,Colombia,Santander,Matanza,NA,SANTANDER,MATANZA
-Colombia-Santander-Mogotes,municipality,Colombia,Santander,Mogotes,NA,SANTANDER,MOGOTES
-Colombia-Santander-Molagavita,municipality,Colombia,Santander,Molagavita,NA,SANTANDER,MOLAGAVITA
-Colombia-Santander-Ocamonte,municipality,Colombia,Santander,Ocamonte,NA,SANTANDER,OCAMONTE
-Colombia-Santander-Oiba,municipality,Colombia,Santander,Oiba,NA,SANTANDER,OIBA
-Colombia-Santander-Onzaga,municipality,Colombia,Santander,Onzaga,NA,SANTANDER,ONZAGA
-Colombia-Santander-Palmar,municipality,Colombia,Santander,Palmar,NA,SANTANDER,PALMAR
-Colombia-Santander-Palmas_Del_Socorro,municipality,Colombia,Santander,Palmas_Del_Socorro,NA,SANTANDER,PALMAS DEL SOCORRO
-Colombia-Santander-Paramo,municipality,Colombia,Santander,Paramo,NA,SANTANDER,PARAMO
-Colombia-Santander-Piedecuesta,municipality,Colombia,Santander,Piedecuesta,NA,SANTANDER,PIEDECUESTA
-Colombia-Santander-Pinchote,municipality,Colombia,Santander,Pinchote,NA,SANTANDER,PINCHOTE
-Colombia-Santander-Puente_Nacional,municipality,Colombia,Santander,Puente_Nacional,NA,SANTANDER,PUENTE NACIONAL
-Colombia-Santander-Puerto_Parra,municipality,Colombia,Santander,Puerto_Parra,NA,SANTANDER,PUERTO PARRA
-Colombia-Santander-Puerto_Wilches,municipality,Colombia,Santander,Puerto_Wilches,NA,SANTANDER,PUERTO WILCHES
-Colombia-Santander-Rionegro,municipality,Colombia,Santander,Rionegro,NA,SANTANDER,RIONEGRO
-Colombia-Santander-Sabana_De_Torres,municipality,Colombia,Santander,Sabana_De_Torres,NA,SANTANDER,SABANA DE TORRES
-Colombia-Santander-San_Andres,municipality,Colombia,Santander,San_Andres,NA,SANTANDER,SAN ANDRES
-Colombia-Santander-San_Benito,municipality,Colombia,Santander,San_Benito,NA,SANTANDER,SAN BENITO
-Colombia-Santander-San_Gil,municipality,Colombia,Santander,San_Gil,NA,SANTANDER,SAN GIL
-Colombia-Santander-San_Joaquin,municipality,Colombia,Santander,San_Joaquin,NA,SANTANDER,SAN JOAQUIN
-Colombia-Santander-San_Jose_De_Miranda,municipality,Colombia,Santander,San_Jose_De_Miranda,NA,SANTANDER,SAN JOSE DE MIRANDA
-Colombia-Santander-San_Miguel,municipality,Colombia,Santander,San_Miguel,NA,SANTANDER,SAN MIGUEL
-Colombia-Santander-San_Vicente_De_Chucuri,municipality,Colombia,Santander,San_Vicente_De_Chucuri,NA,SANTANDER,SAN VICENTE DE CHUCURI
-Colombia-Santander-Santa_Barbara,municipality,Colombia,Santander,Santa_Barbara,NA,SANTANDER,SANTA BARBARA
-Colombia-Santander-Santa_Helena_Del_Opon,municipality,Colombia,Santander,Santa_Helena_Del_Opon,NA,SANTANDER,SANTA HELENA DEL OPON
-Colombia-Santander-Simacota,municipality,Colombia,Santander,Simacota,NA,SANTANDER,SIMACOTA
-Colombia-Santander-Socorro,municipality,Colombia,Santander,Socorro,NA,SANTANDER,SOCORRO
-Colombia-Santander-Suaita,municipality,Colombia,Santander,Suaita,NA,SANTANDER,SUAITA
-Colombia-Santander-Sucre,municipality,Colombia,Santander,Sucre,NA,SANTANDER,SUCRE
-Colombia-Santander-Surata,municipality,Colombia,Santander,Surata,NA,SANTANDER,SURATA
-Colombia-Santander-Tona,municipality,Colombia,Santander,Tona,NA,SANTANDER,TONA
-Colombia-Santander-Valle_De_San_Jose,municipality,Colombia,Santander,Valle_De_San_Jose,NA,SANTANDER,VALLE DE SAN JOSE
-Colombia-Santander-Velez,municipality,Colombia,Santander,Velez,NA,SANTANDER,VELEZ
-Colombia-Santander-Vetas,municipality,Colombia,Santander,Vetas,NA,SANTANDER,VETAS
-Colombia-Santander-Villanueva,municipality,Colombia,Santander,Villanueva,NA,SANTANDER,VILLANUEVA
-Colombia-Santander-Zapatoca,municipality,Colombia,Santander,Zapatoca,NA,SANTANDER,ZAPATOCA
-Colombia-Sucre-Unknown,municipality,Colombia,Sucre,Unknown,NA,SUCRE,* SUCRE. MUNICIPIO DESCONOCIDO
-Colombia-Sucre-Sincelejo,municipality,Colombia,Sucre,Sincelejo,NA,SUCRE,SINCELEJO
-Colombia-Sucre-Buenavista,municipality,Colombia,Sucre,Buenavista,NA,SUCRE,BUENAVISTA
-Colombia-Sucre-Caimito,municipality,Colombia,Sucre,Caimito,NA,SUCRE,CAIMITO
-Colombia-Sucre-Coloso,municipality,Colombia,Sucre,Coloso,NA,SUCRE,COLOSO
-Colombia-Sucre-Corozal,municipality,Colombia,Sucre,Corozal,NA,SUCRE,COROZAL
-Colombia-Sucre-Covenas,municipality,Colombia,Sucre,Covenas,NA,SUCRE,COVEÑAS
-Colombia-Sucre-Chalan,municipality,Colombia,Sucre,Chalan,NA,SUCRE,CHALAN
-Colombia-Sucre-El_Roble,municipality,Colombia,Sucre,El_Roble,NA,SUCRE,EL ROBLE
-Colombia-Sucre-Galeras,municipality,Colombia,Sucre,Galeras,NA,SUCRE,GALERAS
-Colombia-Sucre-Guaranda,municipality,Colombia,Sucre,Guaranda,NA,SUCRE,GUARANDA
-Colombia-Sucre-La_Union,municipality,Colombia,Sucre,La_Union,NA,SUCRE,LA UNION
-Colombia-Sucre-Los_Palmitos,municipality,Colombia,Sucre,Los_Palmitos,NA,SUCRE,LOS PALMITOS
-Colombia-Sucre-Majagual,municipality,Colombia,Sucre,Majagual,NA,SUCRE,MAJAGUAL
-Colombia-Sucre-Morroa,municipality,Colombia,Sucre,Morroa,NA,SUCRE,MORROA
-Colombia-Sucre-Ovejas,municipality,Colombia,Sucre,Ovejas,NA,SUCRE,OVEJAS
-Colombia-Sucre-Palmito,municipality,Colombia,Sucre,Palmito,NA,SUCRE,PALMITO
-Colombia-Sucre-Sampues,municipality,Colombia,Sucre,Sampues,NA,SUCRE,SAMPUES
-Colombia-Sucre-San_Benito_Abad,municipality,Colombia,Sucre,San_Benito_Abad,NA,SUCRE,SAN BENITO ABAD
-Colombia-Sucre-San_Juan_De_Betulia,municipality,Colombia,Sucre,San_Juan_De_Betulia,NA,SUCRE,SAN JUAN DE BETULIA
-Colombia-Sucre-San_Marcos,municipality,Colombia,Sucre,San_Marcos,NA,SUCRE,SAN MARCOS
-Colombia-Sucre-San_Onofre,municipality,Colombia,Sucre,San_Onofre,NA,SUCRE,SAN ONOFRE
-Colombia-Sucre-San_Pedro,municipality,Colombia,Sucre,San_Pedro,NA,SUCRE,SAN PEDRO
-Colombia-Sucre-San_Luis_De_Since,municipality,Colombia,Sucre,San_Luis_De_Since,NA,SUCRE,SAN LUIS DE SINCE
-Colombia-Sucre-Sucre,municipality,Colombia,Sucre,Sucre,NA,SUCRE,SUCRE
-Colombia-Sucre-Santiago_De_Tolu,municipality,Colombia,Sucre,Santiago_De_Tolu,NA,SUCRE,SANTIAGO DE TOLU
-Colombia-Sucre-Tolu_Viejo,municipality,Colombia,Sucre,Tolu_Viejo,NA,SUCRE,TOLU VIEJO
-Colombia-Tolima-Unknown,municipality,Colombia,Tolima,Unknown,NA,TOLIMA,* TOLIMA. MUNICIPIO DESCONOCIDO
-Colombia-Tolima-Ibague,municipality,Colombia,Tolima,Ibague,NA,TOLIMA,IBAGUE
-Colombia-Tolima-Alpujarra,municipality,Colombia,Tolima,Alpujarra,NA,TOLIMA,ALPUJARRA
-Colombia-Tolima-Alvarado,municipality,Colombia,Tolima,Alvarado,NA,TOLIMA,ALVARADO
-Colombia-Tolima-Ambalema,municipality,Colombia,Tolima,Ambalema,NA,TOLIMA,AMBALEMA
-Colombia-Tolima-Anzoategui,municipality,Colombia,Tolima,Anzoategui,NA,TOLIMA,ANZOATEGUI
-Colombia-Tolima-Armero,municipality,Colombia,Tolima,Armero,NA,TOLIMA,ARMERO
-Colombia-Tolima-Ataco,municipality,Colombia,Tolima,Ataco,NA,TOLIMA,ATACO
-Colombia-Tolima-Cajamarca,municipality,Colombia,Tolima,Cajamarca,NA,TOLIMA,CAJAMARCA
-Colombia-Tolima-Carmen_De_Apicala,municipality,Colombia,Tolima,Carmen_De_Apicala,NA,TOLIMA,CARMEN DE APICALA
-Colombia-Tolima-Casabianca,municipality,Colombia,Tolima,Casabianca,NA,TOLIMA,CASABIANCA
-Colombia-Tolima-Chaparral,municipality,Colombia,Tolima,Chaparral,NA,TOLIMA,CHAPARRAL
-Colombia-Tolima-Coello,municipality,Colombia,Tolima,Coello,NA,TOLIMA,COELLO
-Colombia-Tolima-Coyaima,municipality,Colombia,Tolima,Coyaima,NA,TOLIMA,COYAIMA
-Colombia-Tolima-Cunday,municipality,Colombia,Tolima,Cunday,NA,TOLIMA,CUNDAY
-Colombia-Tolima-Dolores,municipality,Colombia,Tolima,Dolores,NA,TOLIMA,DOLORES
-Colombia-Tolima-Espinal,municipality,Colombia,Tolima,Espinal,NA,TOLIMA,ESPINAL
-Colombia-Tolima-Falan,municipality,Colombia,Tolima,Falan,NA,TOLIMA,FALAN
-Colombia-Tolima-Flandes,municipality,Colombia,Tolima,Flandes,NA,TOLIMA,FLANDES
-Colombia-Tolima-Fresno,municipality,Colombia,Tolima,Fresno,NA,TOLIMA,FRESNO
-Colombia-Tolima-Guamo,municipality,Colombia,Tolima,Guamo,NA,TOLIMA,GUAMO
-Colombia-Tolima-Herveo,municipality,Colombia,Tolima,Herveo,NA,TOLIMA,HERVEO
-Colombia-Tolima-Honda,municipality,Colombia,Tolima,Honda,NA,TOLIMA,HONDA
-Colombia-Tolima-Icononzo,municipality,Colombia,Tolima,Icononzo,NA,TOLIMA,ICONONZO
-Colombia-Tolima-Lerida,municipality,Colombia,Tolima,Lerida,NA,TOLIMA,LERIDA
-Colombia-Tolima-Libano,municipality,Colombia,Tolima,Libano,NA,TOLIMA,LIBANO
-Colombia-Tolima-Mariquita,municipality,Colombia,Tolima,Mariquita,NA,TOLIMA,MARIQUITA
-Colombia-Tolima-Melgar,municipality,Colombia,Tolima,Melgar,NA,TOLIMA,MELGAR
-Colombia-Tolima-Murillo,municipality,Colombia,Tolima,Murillo,NA,TOLIMA,MURILLO
-Colombia-Tolima-Natagaima,municipality,Colombia,Tolima,Natagaima,NA,TOLIMA,NATAGAIMA
-Colombia-Tolima-Ortega,municipality,Colombia,Tolima,Ortega,NA,TOLIMA,ORTEGA
-Colombia-Tolima-Palocabildo,municipality,Colombia,Tolima,Palocabildo,NA,TOLIMA,PALOCABILDO
-Colombia-Tolima-Piedras,municipality,Colombia,Tolima,Piedras,NA,TOLIMA,PIEDRAS
-Colombia-Tolima-Planadas,municipality,Colombia,Tolima,Planadas,NA,TOLIMA,PLANADAS
-Colombia-Tolima-Prado,municipality,Colombia,Tolima,Prado,NA,TOLIMA,PRADO
-Colombia-Tolima-Purificacion,municipality,Colombia,Tolima,Purificacion,NA,TOLIMA,PURIFICACION
-Colombia-Tolima-Rioblanco,municipality,Colombia,Tolima,Rioblanco,NA,TOLIMA,RIOBLANCO
-Colombia-Tolima-Roncesvalles,municipality,Colombia,Tolima,Roncesvalles,NA,TOLIMA,RONCESVALLES
-Colombia-Tolima-Rovira,municipality,Colombia,Tolima,Rovira,NA,TOLIMA,ROVIRA
-Colombia-Tolima-Saldana,municipality,Colombia,Tolima,Saldana,NA,TOLIMA,SALDAÑA
-Colombia-Tolima-San_Antonio,municipality,Colombia,Tolima,San_Antonio,NA,TOLIMA,SAN ANTONIO
-Colombia-Tolima-San_Luis,municipality,Colombia,Tolima,San_Luis,NA,TOLIMA,SAN LUIS
-Colombia-Tolima-Santa_Isabel,municipality,Colombia,Tolima,Santa_Isabel,NA,TOLIMA,SANTA ISABEL
-Colombia-Tolima-Suarez,municipality,Colombia,Tolima,Suarez,NA,TOLIMA,SUAREZ
-Colombia-Tolima-Valle_De_San_Juan,municipality,Colombia,Tolima,Valle_De_San_Juan,NA,TOLIMA,VALLE DE SAN JUAN
-Colombia-Tolima-Venadillo,municipality,Colombia,Tolima,Venadillo,NA,TOLIMA,VENADILLO
-Colombia-Tolima-Villahermosa,municipality,Colombia,Tolima,Villahermosa,NA,TOLIMA,VILLAHERMOSA
-Colombia-Tolima-Villarrica,municipality,Colombia,Tolima,Villarrica,NA,TOLIMA,VILLARRICA
-Colombia-Valle_Del_Cauca-Unknown,municipality,Colombia,Valle_Del_Cauca,Unknown,NA,VALLE DEL CAUCA,* VALLE DEL CAUCA. MUNICIPIO DESCONOCIDO
-Colombia-Valle_Del_Cauca-Cali,municipality,Colombia,Valle_Del_Cauca,Cali,NA,VALLE DEL CAUCA,CALI
-Colombia-Valle_Del_Cauca-Alcala,municipality,Colombia,Valle_Del_Cauca,Alcala,NA,VALLE DEL CAUCA,ALCALA
-Colombia-Valle_Del_Cauca-Andalucia,municipality,Colombia,Valle_Del_Cauca,Andalucia,NA,VALLE DEL CAUCA,ANDALUCIA
-Colombia-Valle_Del_Cauca-Ansermanuevo,municipality,Colombia,Valle_Del_Cauca,Ansermanuevo,NA,VALLE DEL CAUCA,ANSERMANUEVO
-Colombia-Valle_Del_Cauca-Argelia,municipality,Colombia,Valle_Del_Cauca,Argelia,NA,VALLE DEL CAUCA,ARGELIA
-Colombia-Valle_Del_Cauca-Bolivar,municipality,Colombia,Valle_Del_Cauca,Bolivar,NA,VALLE DEL CAUCA,BOLIVAR
-Colombia-Valle_Del_Cauca-Buenaventura,municipality,Colombia,Valle_Del_Cauca,Buenaventura,NA,VALLE DEL CAUCA,BUENAVENTURA
-Colombia-Valle_Del_Cauca-Guadalajara_De_Buga,municipality,Colombia,Valle_Del_Cauca,Guadalajara_De_Buga,NA,VALLE DEL CAUCA,GUADALAJARA DE BUGA
-Colombia-Valle_Del_Cauca-Bugalagrande,municipality,Colombia,Valle_Del_Cauca,Bugalagrande,NA,VALLE DEL CAUCA,BUGALAGRANDE
-Colombia-Valle_Del_Cauca-Caicedonia,municipality,Colombia,Valle_Del_Cauca,Caicedonia,NA,VALLE DEL CAUCA,CAICEDONIA
-Colombia-Valle_Del_Cauca-Calima,municipality,Colombia,Valle_Del_Cauca,Calima,NA,VALLE DEL CAUCA,CALIMA
-Colombia-Valle_Del_Cauca-Candelaria,municipality,Colombia,Valle_Del_Cauca,Candelaria,NA,VALLE DEL CAUCA,CANDELARIA
-Colombia-Valle_Del_Cauca-Cartago,municipality,Colombia,Valle_Del_Cauca,Cartago,NA,VALLE DEL CAUCA,CARTAGO
-Colombia-Valle_Del_Cauca-Dagua,municipality,Colombia,Valle_Del_Cauca,Dagua,NA,VALLE DEL CAUCA,DAGUA
-Colombia-Valle_Del_Cauca-El_Aguila,municipality,Colombia,Valle_Del_Cauca,El_Aguila,NA,VALLE DEL CAUCA,EL AGUILA
-Colombia-Valle_Del_Cauca-El_Cairo,municipality,Colombia,Valle_Del_Cauca,El_Cairo,NA,VALLE DEL CAUCA,EL CAIRO
-Colombia-Valle_Del_Cauca-El_Cerrito,municipality,Colombia,Valle_Del_Cauca,El_Cerrito,NA,VALLE DEL CAUCA,EL CERRITO
-Colombia-Valle_Del_Cauca-El_Dovio,municipality,Colombia,Valle_Del_Cauca,El_Dovio,NA,VALLE DEL CAUCA,EL DOVIO
-Colombia-Valle_Del_Cauca-Florida,municipality,Colombia,Valle_Del_Cauca,Florida,NA,VALLE DEL CAUCA,FLORIDA
-Colombia-Valle_Del_Cauca-Ginebra,municipality,Colombia,Valle_Del_Cauca,Ginebra,NA,VALLE DEL CAUCA,GINEBRA
-Colombia-Valle_Del_Cauca-Guacari,municipality,Colombia,Valle_Del_Cauca,Guacari,NA,VALLE DEL CAUCA,GUACARI
-Colombia-Valle_Del_Cauca-Jamundi,municipality,Colombia,Valle_Del_Cauca,Jamundi,NA,VALLE DEL CAUCA,JAMUNDI
-Colombia-Valle_Del_Cauca-La_Cumbre,municipality,Colombia,Valle_Del_Cauca,La_Cumbre,NA,VALLE DEL CAUCA,LA CUMBRE
-Colombia-Valle_Del_Cauca-La_Union,municipality,Colombia,Valle_Del_Cauca,La_Union,NA,VALLE DEL CAUCA,LA UNION
-Colombia-Valle_Del_Cauca-La_Victoria,municipality,Colombia,Valle_Del_Cauca,La_Victoria,NA,VALLE DEL CAUCA,LA VICTORIA
-Colombia-Valle_Del_Cauca-Obando,municipality,Colombia,Valle_Del_Cauca,Obando,NA,VALLE DEL CAUCA,OBANDO
-Colombia-Valle_Del_Cauca-Palmira,municipality,Colombia,Valle_Del_Cauca,Palmira,NA,VALLE DEL CAUCA,PALMIRA
-Colombia-Valle_Del_Cauca-Pradera,municipality,Colombia,Valle_Del_Cauca,Pradera,NA,VALLE DEL CAUCA,PRADERA
-Colombia-Valle_Del_Cauca-Restrepo,municipality,Colombia,Valle_Del_Cauca,Restrepo,NA,VALLE DEL CAUCA,RESTREPO
-Colombia-Valle_Del_Cauca-Riofrio,municipality,Colombia,Valle_Del_Cauca,Riofrio,NA,VALLE DEL CAUCA,RIOFRIO
-Colombia-Valle_Del_Cauca-Roldanillo,municipality,Colombia,Valle_Del_Cauca,Roldanillo,NA,VALLE DEL CAUCA,ROLDANILLO
-Colombia-Valle_Del_Cauca-San_Pedro,municipality,Colombia,Valle_Del_Cauca,San_Pedro,NA,VALLE DEL CAUCA,SAN PEDRO
-Colombia-Valle_Del_Cauca-Sevilla,municipality,Colombia,Valle_Del_Cauca,Sevilla,NA,VALLE DEL CAUCA,SEVILLA
-Colombia-Valle_Del_Cauca-Toro,municipality,Colombia,Valle_Del_Cauca,Toro,NA,VALLE DEL CAUCA,TORO
-Colombia-Valle_Del_Cauca-Trujillo,municipality,Colombia,Valle_Del_Cauca,Trujillo,NA,VALLE DEL CAUCA,TRUJILLO
-Colombia-Valle_Del_Cauca-Tulua,municipality,Colombia,Valle_Del_Cauca,Tulua,NA,VALLE DEL CAUCA,TULUA
-Colombia-Valle_Del_Cauca-Ulloa,municipality,Colombia,Valle_Del_Cauca,Ulloa,NA,VALLE DEL CAUCA,ULLOA
-Colombia-Valle_Del_Cauca-Versalles,municipality,Colombia,Valle_Del_Cauca,Versalles,NA,VALLE DEL CAUCA,VERSALLES
-Colombia-Valle_Del_Cauca-Vijes,municipality,Colombia,Valle_Del_Cauca,Vijes,NA,VALLE DEL CAUCA,VIJES
-Colombia-Valle_Del_Cauca-Yotoco,municipality,Colombia,Valle_Del_Cauca,Yotoco,NA,VALLE DEL CAUCA,YOTOCO
-Colombia-Valle_Del_Cauca-Yumbo,municipality,Colombia,Valle_Del_Cauca,Yumbo,NA,VALLE DEL CAUCA,YUMBO
-Colombia-Valle_Del_Cauca-Zarzal,municipality,Colombia,Valle_Del_Cauca,Zarzal,NA,VALLE DEL CAUCA,ZARZAL
-Colombia-Arauca-Unknown,municipality,Colombia,Arauca,Unknown,NA,ARAUCA,* ARAUCA. MUNICIPIO DESCONOCIDO
-Colombia-Arauca-Arauca,municipality,Colombia,Arauca,Arauca,NA,ARAUCA,ARAUCA
-Colombia-Arauca-Arauquita,municipality,Colombia,Arauca,Arauquita,NA,ARAUCA,ARAUQUITA
-Colombia-Arauca-Cravo_Norte,municipality,Colombia,Arauca,Cravo_Norte,NA,ARAUCA,CRAVO NORTE
-Colombia-Arauca-Fortul,municipality,Colombia,Arauca,Fortul,NA,ARAUCA,FORTUL
-Colombia-Arauca-Puerto_Rondon,municipality,Colombia,Arauca,Puerto_Rondon,NA,ARAUCA,PUERTO RONDON
-Colombia-Arauca-Saravena,municipality,Colombia,Arauca,Saravena,NA,ARAUCA,SARAVENA
-Colombia-Arauca-Tame,municipality,Colombia,Arauca,Tame,NA,ARAUCA,TAME
-Colombia-Casanare-Unknown,municipality,Colombia,Casanare,Unknown,NA,CASANARE,* CASANARE. MUNICIPIO DESCONOCIDO
-Colombia-Casanare-Yopal,municipality,Colombia,Casanare,Yopal,NA,CASANARE,YOPAL
-Colombia-Casanare-Aguazul,municipality,Colombia,Casanare,Aguazul,NA,CASANARE,AGUAZUL
-Colombia-Casanare-Chameza,municipality,Colombia,Casanare,Chameza,NA,CASANARE,CHAMEZA
-Colombia-Casanare-Hato_Corozal,municipality,Colombia,Casanare,Hato_Corozal,NA,CASANARE,HATO COROZAL
-Colombia-Casanare-La_Salina,municipality,Colombia,Casanare,La_Salina,NA,CASANARE,LA SALINA
-Colombia-Casanare-Mani,municipality,Colombia,Casanare,Mani,NA,CASANARE,MANI
-Colombia-Casanare-Monterrey,municipality,Colombia,Casanare,Monterrey,NA,CASANARE,MONTERREY
-Colombia-Casanare-Nunchia,municipality,Colombia,Casanare,Nunchia,NA,CASANARE,NUNCHIA
-Colombia-Casanare-Orocue,municipality,Colombia,Casanare,Orocue,NA,CASANARE,OROCUE
-Colombia-Casanare-Paz_De_Ariporo,municipality,Colombia,Casanare,Paz_De_Ariporo,NA,CASANARE,PAZ DE ARIPORO
-Colombia-Casanare-Pore,municipality,Colombia,Casanare,Pore,NA,CASANARE,PORE
-Colombia-Casanare-Recetor,municipality,Colombia,Casanare,Recetor,NA,CASANARE,RECETOR
-Colombia-Casanare-Sabanalarga,municipality,Colombia,Casanare,Sabanalarga,NA,CASANARE,SABANALARGA
-Colombia-Casanare-Sacama,municipality,Colombia,Casanare,Sacama,NA,CASANARE,SACAMA
-Colombia-Casanare-San_Luis_De_Palenque,municipality,Colombia,Casanare,San_Luis_De_Palenque,NA,CASANARE,SAN LUIS DE PALENQUE
-Colombia-Casanare-Tamara,municipality,Colombia,Casanare,Tamara,NA,CASANARE,TAMARA
-Colombia-Casanare-Tauramena,municipality,Colombia,Casanare,Tauramena,NA,CASANARE,TAURAMENA
-Colombia-Casanare-Trinidad,municipality,Colombia,Casanare,Trinidad,NA,CASANARE,TRINIDAD
-Colombia-Casanare-Villanueva,municipality,Colombia,Casanare,Villanueva,NA,CASANARE,VILLANUEVA
-Colombia-Putumayo-Unknown,municipality,Colombia,Putumayo,Unknown,NA,PUTUMAYO,* PUTUMAYO. MUNICIPIO DESCONOCIDO
-Colombia-Putumayo-Mocoa,municipality,Colombia,Putumayo,Mocoa,NA,PUTUMAYO,MOCOA
-Colombia-Putumayo-Colon,municipality,Colombia,Putumayo,Colon,NA,PUTUMAYO,COLON
-Colombia-Putumayo-Orito,municipality,Colombia,Putumayo,Orito,NA,PUTUMAYO,ORITO
-Colombia-Putumayo-Puerto_Asis,municipality,Colombia,Putumayo,Puerto_Asis,NA,PUTUMAYO,PUERTO ASIS
-Colombia-Putumayo-Puerto_Caicedo,municipality,Colombia,Putumayo,Puerto_Caicedo,NA,PUTUMAYO,PUERTO CAICEDO
-Colombia-Putumayo-Puerto_Guzman,municipality,Colombia,Putumayo,Puerto_Guzman,NA,PUTUMAYO,PUERTO GUZMAN
-Colombia-Putumayo-Leguizamo,municipality,Colombia,Putumayo,Leguizamo,NA,PUTUMAYO,LEGUIZAMO
-Colombia-Putumayo-Sibundoy,municipality,Colombia,Putumayo,Sibundoy,NA,PUTUMAYO,SIBUNDOY
-Colombia-Putumayo-San_Francisco,municipality,Colombia,Putumayo,San_Francisco,NA,PUTUMAYO,SAN FRANCISCO
-Colombia-Putumayo-San_Miguel,municipality,Colombia,Putumayo,San_Miguel,NA,PUTUMAYO,SAN MIGUEL
-Colombia-Putumayo-Santiago,municipality,Colombia,Putumayo,Santiago,NA,PUTUMAYO,SANTIAGO
-Colombia-Putumayo-Valle_Del_Guamuez,municipality,Colombia,Putumayo,Valle_Del_Guamuez,NA,PUTUMAYO,VALLE DEL GUAMUEZ
-Colombia-Putumayo-Villagarzon,municipality,Colombia,Putumayo,Villagarzon,NA,PUTUMAYO,VILLAGARZON
-Colombia-San_Andres-Unknown,municipality,Colombia,San_Andres,Unknown,NA,SAN ANDRES,* SAN ANDRES. MUNICIPIO DESCONOCIDO
-Colombia-San_Andres-San_Andres,municipality,Colombia,San_Andres,San_Andres,NA,SAN ANDRES,SAN ANDRES
-Colombia-San_Andres-Providencia,municipality,Colombia,San_Andres,Providencia,NA,SAN ANDRES,PROVIDENCIA
-Colombia-Amazonas-Unknown,municipality,Colombia,Amazonas,Unknown,NA,AMAZONAS,* AMAZONAS. MUNICIPIO DESCONOCIDO
-Colombia-Amazonas-Leticia,municipality,Colombia,Amazonas,Leticia,NA,AMAZONAS,LETICIA
-Colombia-Amazonas-El_Encanto,municipality,Colombia,Amazonas,El_Encanto,NA,AMAZONAS,EL ENCANTO
-Colombia-Amazonas-La_Chorrera,municipality,Colombia,Amazonas,La_Chorrera,NA,AMAZONAS,LA CHORRERA
-Colombia-Amazonas-La_Pedrera,municipality,Colombia,Amazonas,La_Pedrera,NA,AMAZONAS,LA PEDRERA
-Colombia-Amazonas-La_Victoria,municipality,Colombia,Amazonas,La_Victoria,NA,AMAZONAS,LA VICTORIA
-Colombia-Amazonas-Miriti_Parana,municipality,Colombia,Amazonas,Miriti_Parana,NA,AMAZONAS,MIRITI - PARANA
-Colombia-Amazonas-Puerto_Alegria,municipality,Colombia,Amazonas,Puerto_Alegria,NA,AMAZONAS,PUERTO ALEGRIA
-Colombia-Amazonas-Puerto_Arica,municipality,Colombia,Amazonas,Puerto_Arica,NA,AMAZONAS,PUERTO ARICA
-Colombia-Amazonas-Puerto_Narino,municipality,Colombia,Amazonas,Puerto_Narino,NA,AMAZONAS,PUERTO NARIÑO
-Colombia-Amazonas-Puerto_Santander,municipality,Colombia,Amazonas,Puerto_Santander,NA,AMAZONAS,PUERTO SANTANDER
-Colombia-Amazonas-Tarapaca,municipality,Colombia,Amazonas,Tarapaca,NA,AMAZONAS,TARAPACA
-Colombia-Guainia-Unknown,municipality,Colombia,Guainia,Unknown,NA,GUAINIA,* GUAINIA. MUNICIPIO DESCONOCIDO
-Colombia-Guainia-Inirida,municipality,Colombia,Guainia,Inirida,NA,GUAINIA,INIRIDA
-Colombia-Guainia-Barranco_Minas,municipality,Colombia,Guainia,Barranco_Minas,NA,GUAINIA,BARRANCO MINAS
-Colombia-Guainia-Mapiripana,municipality,Colombia,Guainia,Mapiripana,NA,GUAINIA,MAPIRIPANA
-Colombia-Guainia-San_Felipe,municipality,Colombia,Guainia,San_Felipe,NA,GUAINIA,SAN FELIPE
-Colombia-Guainia-Puerto_Colombia,municipality,Colombia,Guainia,Puerto_Colombia,NA,GUAINIA,PUERTO COLOMBIA
-Colombia-Guainia-La_Guadalupe,municipality,Colombia,Guainia,La_Guadalupe,NA,GUAINIA,LA GUADALUPE
-Colombia-Guainia-Cacahual,municipality,Colombia,Guainia,Cacahual,NA,GUAINIA,CACAHUAL
-Colombia-Guainia-Pana_Pana,municipality,Colombia,Guainia,Pana_Pana,NA,GUAINIA,PANA PANA
-Colombia-Guainia-Morichal,municipality,Colombia,Guainia,Morichal,NA,GUAINIA,MORICHAL
-Colombia-Guaviare-Unknown,municipality,Colombia,Guaviare,Unknown,NA,GUAVIARE,* GUAVIARE. MUNICIPIO DESCONOCIDO
-Colombia-Guaviare-San_Jose_Del_Guaviare,municipality,Colombia,Guaviare,San_Jose_Del_Guaviare,NA,GUAVIARE,SAN JOSE DEL GUAVIARE
-Colombia-Guaviare-Calamar,municipality,Colombia,Guaviare,Calamar,NA,GUAVIARE,CALAMAR
-Colombia-Guaviare-El_Retorno,municipality,Colombia,Guaviare,El_Retorno,NA,GUAVIARE,EL RETORNO
-Colombia-Guaviare-Miraflores,municipality,Colombia,Guaviare,Miraflores,NA,GUAVIARE,MIRAFLORES
-Colombia-Vaupes-Unknown,municipality,Colombia,Vaupes,Unknown,NA,VAUPES,* VAUPES. MUNICIPIO DESCONOCIDO
-Colombia-Vaupes-Mitu,municipality,Colombia,Vaupes,Mitu,NA,VAUPES,MITU
-Colombia-Vaupes-Caruru,municipality,Colombia,Vaupes,Caruru,NA,VAUPES,CARURU
-Colombia-Vaupes-Pacoa,municipality,Colombia,Vaupes,Pacoa,NA,VAUPES,PACOA
-Colombia-Vaupes-Taraira,municipality,Colombia,Vaupes,Taraira,NA,VAUPES,TARAIRA
-Colombia-Vaupes-Papunaua,municipality,Colombia,Vaupes,Papunaua,NA,VAUPES,PAPUNAUA
-Colombia-Vaupes-Yavarate,municipality,Colombia,Vaupes,Yavarate,NA,VAUPES,YAVARATE
-Colombia-Vichada-Unknown,municipality,Colombia,Vichada,Unknown,NA,VICHADA,* VICHADA. MUNICIPIO DESCONOCIDO
-Colombia-Vichada-Puerto_Carreno,municipality,Colombia,Vichada,Puerto_Carreno,NA,VICHADA,PUERTO CARREÑO
-Colombia-Vichada-La_Primavera,municipality,Colombia,Vichada,La_Primavera,NA,VICHADA,LA PRIMAVERA
-Colombia-Vichada-Santa_Rosalia,municipality,Colombia,Vichada,Santa_Rosalia,NA,VICHADA,SANTA ROSALIA
-Colombia-Vichada-Cumaribo,municipality,Colombia,Vichada,Cumaribo,NA,VICHADA,CUMARIBO
-Colombia-Desconocido-Desconocido,municipality,Colombia,Desconocido,Desconocido,NA,DESCONOCIDO,DESCONOCIDO
-Colombia-Bogota-Bogota,municipality,Colombia,Bogota,Bogota,NA,BOGOTA,BOGOTA
-"Colombia-Bogota-Bogota,_D.C.",municipality,Colombia,Bogota,"Bogota,_D.C.",NA,BOGOTA,"BOGOTA, D.C."
-Colombia-Bogota-Usaquen_Los_Cedros,municipality,Colombia,Bogota,Usaquen_Los_Cedros,NA,BOGOTA,BOGOTÁ - USAQUÉN-LOS CEDROS
-Colombia-Bogota-Usaquen_Santa_Barbara,municipality,Colombia,Bogota,Usaquen_Santa_Barbara,NA,BOGOTA,BOGOTÁ - USAQUÉN-SANTA BÁRBARA
-Colombia-Bogota-Barrios_Unidos_Los_Andes,municipality,Colombia,Bogota,Barrios_Unidos_Los_Andes,NA,BOGOTA,BOGOTÁ - BARRIOS UNIDOS-LOS ANDES
-Colombia-Bogota-Barrios_Unidos_12_De_Octubre,municipality,Colombia,Bogota,Barrios_Unidos_12_De_Octubre,NA,BOGOTA,BOGOTÁ - BARRIOS UNIDOS-12 DE OCTUBRE
-Colombia-Bogota-San_Cristobal_Sociego,municipality,Colombia,Bogota,San_Cristobal_Sociego,NA,BOGOTA,BOGOTÁ - SAN CRISTÓBAL-SOCIEGO
-Colombia-Bogota-Tunjuelito_Venecia,municipality,Colombia,Bogota,Tunjuelito_Venecia,NA,BOGOTA,BOGOTÁ - TUNJUELITO-VENECIA
-Colombia-Bogota-Puente_Aranda_San_Rafael,municipality,Colombia,Bogota,Puente_Aranda_San_Rafael,NA,BOGOTA,BOGOTÁ - PUENTE ARANDA-SAN RAFAEL
-Colombia-Bogota-Kennedy_Americas,municipality,Colombia,Bogota,Kennedy_Americas,NA,BOGOTA,BOGOTÁ - KENNEDY-AMÉRICAS
-Colombia-Bogota-Kennedy_Kennedy_Central,municipality,Colombia,Bogota,Kennedy_Kennedy_Central,NA,BOGOTA,BOGOTÁ - KENNEDY-KENNEDY CENTRAL
-Colombia-Bogota-Tunjuelito_Tunjuelito,municipality,Colombia,Bogota,Tunjuelito_Tunjuelito,NA,BOGOTA,BOGOTÁ - TUNJUELITO-TUNJUELITO
-Colombia-Bogota-Ciudad_Bolivar_San_Francisco,municipality,Colombia,Bogota,Ciudad_Bolivar_San_Francisco,NA,BOGOTA,BOGOTÁ - CIUDAD BOLÍVAR-SAN FRANCISCO
-Colombia-Bogota-Engativa_Engativa,municipality,Colombia,Bogota,Engativa_Engativa,NA,BOGOTA,BOGOTÁ - ENGATIVÁ-ENGATIVÁ
-Colombia-Bogota-Fontibon_Fontibon,municipality,Colombia,Bogota,Fontibon_Fontibon,NA,BOGOTA,BOGOTÁ - FONTIBÓN-FONTIBÓN
-Colombia-Bogota-Bosa_Bosa_Central,municipality,Colombia,Bogota,Bosa_Bosa_Central,NA,BOGOTA,BOGOTÁ - BOSA-BOSA CENTRAL
-Colombia-Bogota-Bosa_Tintal_Sur,municipality,Colombia,Bogota,Bosa_Tintal_Sur,NA,BOGOTA,BOGOTÁ - BOSA-TINTAL SUR
-Colombia-Bogota-La_Candelaria_La_Candelaria,municipality,Colombia,Bogota,La_Candelaria_La_Candelaria,NA,BOGOTA,BOGOTÁ - LA CANDELARIA-LA CANDELARIA
-Colombia-Bogota-Chapinero_Chico_Lago,municipality,Colombia,Bogota,Chapinero_Chico_Lago,NA,BOGOTA,BOGOTÁ - CHAPINERO-CHICO LAGO
-Colombia-Bogota-Chapinero_Chapinero,municipality,Colombia,Bogota,Chapinero_Chapinero,NA,BOGOTA,BOGOTÁ - CHAPINERO-CHAPINERO
-Colombia-Bogota-Teusaquillo_Teusaquillo,municipality,Colombia,Bogota,Teusaquillo_Teusaquillo,NA,BOGOTA,BOGOTÁ - TEUSAQUILLO-TEUSAQUILLO
-Colombia-Bogota-Teusaquillo_La_Esmeralda,municipality,Colombia,Bogota,Teusaquillo_La_Esmeralda,NA,BOGOTA,BOGOTÁ - TEUSAQUILLO-LA ESMERALDA
-Colombia-Bogota-Teusaquillo_Quinta_Paredes,municipality,Colombia,Bogota,Teusaquillo_Quinta_Paredes,NA,BOGOTA,BOGOTÁ - TEUSAQUILLO-QUINTA PAREDES
-Colombia-Bogota-Teusaquillo_Ciudad_Salitre_Oriental,municipality,Colombia,Bogota,Teusaquillo_Ciudad_Salitre_Oriental,NA,BOGOTA,BOGOTÁ - TEUSAQUILLO-CIUDAD SALITRE ORIENTAL
-Colombia-Sucre-Tolu,municipality,Colombia,Sucre,Tolu,NA,SUCRE,TOLU
-Colombia-Sucre-Toluviejo,municipality,Colombia,Sucre,Toluviejo,NA,SUCRE,TOLUVIEJO
-Colombia-Tolima-Armero_(Guayabal),municipality,Colombia,Tolima,Armero_(Guayabal),NA,TOLIMA,ARMERO (GUAYABAL)
-Colombia-unknown-unknown,municipality,Colombia,unknown,unknown,NA,NA,NA
-Colombia-Valle,province,Colombia,Valle,NA,NA,NA,NA
-Colombia-Norte_Santander,province,Colombia,NorteSantander,NA,NA,NA,NA
-Colombia-Barranquilla,province,Colombia,Barranquilla,NA,NA,NA,NA
-Colombia-Huila,province,Colombia,Huila,NA,NA,NA,NA
-Colombia-Santander,province,Colombia,Santander,NA,NA,NA,NA
-Colombia-C�rdoba,province,Colombia,C�rdoba,NA,NA,NA,NA
-Colombia-Meta,province,Colombia,Meta,NA,NA,NA,NA
-Colombia-Tolima,province,Colombia,Tolima,NA,NA,NA,NA
-Colombia-Atl�ntico,province,Colombia,Atl�ntico,NA,NA,NA,NA
-Colombia-Cesar,province,Colombia,Cesar,NA,NA,NA,NA
-Colombia-Antioquia,province,Colombia,Antioquia,NA,NA,NA,NA
-Colombia-Casanare,province,Colombia,Casanare,NA,NA,NA,NA
-Colombia-Santa_Marta,province,Colombia,SantaMarta,NA,NA,NA,NA
-Colombia-Sucre,province,Colombia,Sucre,NA,NA,NA,NA
-Colombia-Magdalena,province,Colombia,Magdalena,NA,NA,NA,NA
-Colombia-Bogot�,province,Colombia,Bogot�,NA,NA,NA,NA
-Colombia-Caquet�,province,Colombia,Caquet�,NA,NA,NA,NA
-Colombia-Cundinamarca,province,Colombia,Cundinamarca,NA,NA,NA,NA
-Colombia-Arauca,province,Colombia,Arauca,NA,NA,NA,NA
-Colombia-Guajira,province,Colombia,Guajira,NA,NA,NA,NA
-Colombia-Risaralda,province,Colombia,Risaralda,NA,NA,NA,NA
-Colombia-Bol�var,province,Colombia,Bol�var,NA,NA,NA,NA
-Colombia-Putumayo,province,Colombia,Putumayo,NA,NA,NA,NA
-Colombia-Cartagena,province,Colombia,Cartagena,NA,NA,NA,NA
-Colombia-Cauca,province,Colombia,Cauca,NA,NA,NA,NA
-Colombia-Quind�o,province,Colombia,Quind�o,NA,NA,NA,NA
-Colombia-Caldas,province,Colombia,Caldas,NA,NA,NA,NA
-Colombia-Amazonas,province,Colombia,Amazonas,NA,NA,NA,NA
-Colombia-Boyac�,province,Colombia,Boyac�,NA,NA,NA,NA
-Colombia-San_Andr�s,province,Colombia,SanAndr�s,NA,NA,NA,NA
-Colombia-Buenaventura,province,Colombia,Buenaventura,NA,NA,NA,NA
-Colombia-Nari�o,province,Colombia,Nari�o,NA,NA,NA,NA
-Colombia-Guaviare,province,Colombia,Guaviare,NA,NA,NA,NA
-Colombia-Vichada,province,Colombia,Vichada,NA,NA,NA,NA
-Colombia-Choco,province,Colombia,Choco,NA,NA,NA,NA
-Colombia-Vaup�s,province,Colombia,Vaup�s,NA,NA,NA,NA
-Colombia-Guain�a,province,Colombia,Guain�a,NA,NA,NA,NA
-Colombia-Exterior,province,Colombia,Exterior,NA,NA,NA,NA
+location,location_type,country,state_province,district_county_municipality,city,alt_name1,alt_name2,id
+Colombia-Cundinamarca-Rafael_Reyes_(Apulo),municipality,Colombia,Cundinamarca,Rafael_Reyes_(Apulo),NA,CUNDINAMARCA,Rafael_Reyes_(Apulo),
+Colombia-Sucre-Santiago_De_Tolu,municipality,Colombia,Sucre,Santiago_De_Tolu,NA,SUCRE,SANTIAGO DE TOLU,
+Colombia-Sucre-Tolu_Viejo,municipality,Colombia,Sucre,Tolu_Viejo,NA,SUCRE,TOLU VIEJO,
+Colombia-Tolima-Armero,municipality,Colombia,Tolima,Armero,NA,TOLIMA,ARMERO,
+Colombia-Bogota-Bogota,municipality,Colombia,Bogota,Bogota,NA,BOGOTA,BOGOTA,
+"Colombia-Bogota-Bogota,_D.C.",municipality,Colombia,Bogota,"Bogota,_D.C.",NA,BOGOTA,"BOGOTA, D.C.",
+Colombia-Bogota-Usaquen_Los_Cedros,municipality,Colombia,Bogota,Usaquen_Los_Cedros,NA,BOGOTA,BOGOTÁ - USAQUÉN-LOS CEDROS,
+Colombia-Bogota-Usaquen_Santa_Barbara,municipality,Colombia,Bogota,Usaquen_Santa_Barbara,NA,BOGOTA,BOGOTÁ - USAQUÉN-SANTA BÁRBARA,
+Colombia-Bogota-Barrios_Unidos_Los_Andes,municipality,Colombia,Bogota,Barrios_Unidos_Los_Andes,NA,BOGOTA,BOGOTÁ - BARRIOS UNIDOS-LOS ANDES,
+Colombia-Bogota-Barrios_Unidos_12_De_Octubre,municipality,Colombia,Bogota,Barrios_Unidos_12_De_Octubre,NA,BOGOTA,BOGOTÁ - BARRIOS UNIDOS-12 DE OCTUBRE,
+Colombia-Bogota-San_Cristobal_Sociego,municipality,Colombia,Bogota,San_Cristobal_Sociego,NA,BOGOTA,BOGOTÁ - SAN CRISTÓBAL-SOCIEGO,
+Colombia-Bogota-Tunjuelito_Venecia,municipality,Colombia,Bogota,Tunjuelito_Venecia,NA,BOGOTA,BOGOTÁ - TUNJUELITO-VENECIA,
+Colombia-Bogota-Puente_Aranda_San_Rafael,municipality,Colombia,Bogota,Puente_Aranda_San_Rafael,NA,BOGOTA,BOGOTÁ - PUENTE ARANDA-SAN RAFAEL,
+Colombia-Bogota-Kennedy_Americas,municipality,Colombia,Bogota,Kennedy_Americas,NA,BOGOTA,BOGOTÁ - KENNEDY-AMÉRICAS,
+Colombia-Bogota-Kennedy_Kennedy_Central,municipality,Colombia,Bogota,Kennedy_Kennedy_Central,NA,BOGOTA,BOGOTÁ - KENNEDY-KENNEDY CENTRAL,
+Colombia-Bogota-Tunjuelito_Tunjuelito,municipality,Colombia,Bogota,Tunjuelito_Tunjuelito,NA,BOGOTA,BOGOTÁ - TUNJUELITO-TUNJUELITO,
+Colombia-Bogota-Ciudad_Bolivar_San_Francisco,municipality,Colombia,Bogota,Ciudad_Bolivar_San_Francisco,NA,BOGOTA,BOGOTÁ - CIUDAD BOLÍVAR-SAN FRANCISCO,
+Colombia-Bogota-Engativa_Engativa,municipality,Colombia,Bogota,Engativa_Engativa,NA,BOGOTA,BOGOTÁ - ENGATIVÁ-ENGATIVÁ,
+Colombia-Bogota-Fontibon_Fontibon,municipality,Colombia,Bogota,Fontibon_Fontibon,NA,BOGOTA,BOGOTÁ - FONTIBÓN-FONTIBÓN,
+Colombia-Bogota-Bosa_Bosa_Central,municipality,Colombia,Bogota,Bosa_Bosa_Central,NA,BOGOTA,BOGOTÁ - BOSA-BOSA CENTRAL,
+Colombia-Bogota-Bosa_Tintal_Sur,municipality,Colombia,Bogota,Bosa_Tintal_Sur,NA,BOGOTA,BOGOTÁ - BOSA-TINTAL SUR,
+Colombia-Bogota-La_Candelaria_La_Candelaria,municipality,Colombia,Bogota,La_Candelaria_La_Candelaria,NA,BOGOTA,BOGOTÁ - LA CANDELARIA-LA CANDELARIA,
+Colombia-Bogota-Chapinero_Chico_Lago,municipality,Colombia,Bogota,Chapinero_Chico_Lago,NA,BOGOTA,BOGOTÁ - CHAPINERO-CHICO LAGO,
+Colombia-Bogota-Chapinero_Chapinero,municipality,Colombia,Bogota,Chapinero_Chapinero,NA,BOGOTA,BOGOTÁ - CHAPINERO-CHAPINERO,
+Colombia-Bogota-Teusaquillo_Teusaquillo,municipality,Colombia,Bogota,Teusaquillo_Teusaquillo,NA,BOGOTA,BOGOTÁ - TEUSAQUILLO-TEUSAQUILLO,
+Colombia-Bogota-Teusaquillo_La_Esmeralda,municipality,Colombia,Bogota,Teusaquillo_La_Esmeralda,NA,BOGOTA,BOGOTÁ - TEUSAQUILLO-LA ESMERALDA,
+Colombia-Bogota-Teusaquillo_Quinta_Paredes,municipality,Colombia,Bogota,Teusaquillo_Quinta_Paredes,NA,BOGOTA,BOGOTÁ - TEUSAQUILLO-QUINTA PAREDES,
+Colombia-Bogota-Teusaquillo_Ciudad_Salitre_Oriental,municipality,Colombia,Bogota,Teusaquillo_Ciudad_Salitre_Oriental,NA,BOGOTA,BOGOTÁ - TEUSAQUILLO-CIUDAD SALITRE ORIENTAL,
+Colombia-Antioquia-Unknown,municipality,Colombia,Antioquia,Unknown,NA,ANTIOQUIA,* ANTIOQUIA. MUNICIPIO DESCONOCIDO,05000
+Colombia-Antioquia-Medellin,municipality,Colombia,Antioquia,Medellin,NA,ANTIOQUIA,MEDELLIN,05001
+Colombia-Antioquia-Abejorral,municipality,Colombia,Antioquia,Abejorral,NA,ANTIOQUIA,ABEJORRAL,05002
+Colombia-Antioquia-Abriaqui,municipality,Colombia,Antioquia,Abriaqui,NA,ANTIOQUIA,ABRIAQUI,05004
+Colombia-Antioquia-Alejandria,municipality,Colombia,Antioquia,Alejandria,NA,ANTIOQUIA,ALEJANDRIA,05021
+Colombia-Antioquia-Amaga,municipality,Colombia,Antioquia,Amaga,NA,ANTIOQUIA,AMAGA,05030
+Colombia-Antioquia-Amalfi,municipality,Colombia,Antioquia,Amalfi,NA,ANTIOQUIA,AMALFI,05031
+Colombia-Antioquia-Andes,municipality,Colombia,Antioquia,Andes,NA,ANTIOQUIA,ANDES,05034
+Colombia-Antioquia-Angelopolis,municipality,Colombia,Antioquia,Angelopolis,NA,ANTIOQUIA,ANGELOPOLIS,05036
+Colombia-Antioquia-Angostura,municipality,Colombia,Antioquia,Angostura,NA,ANTIOQUIA,ANGOSTURA,05038
+Colombia-Antioquia-Anori,municipality,Colombia,Antioquia,Anori,NA,ANTIOQUIA,ANORI,05040
+Colombia-Antioquia-Santafe_De_Antioquia,municipality,Colombia,Antioquia,Santafe_De_Antioquia,NA,ANTIOQUIA,SANTAFE DE ANTIOQUIA,05042
+Colombia-Antioquia-Anza,municipality,Colombia,Antioquia,Anza,NA,ANTIOQUIA,ANZA,05044
+Colombia-Antioquia-Apartado,municipality,Colombia,Antioquia,Apartado,NA,ANTIOQUIA,APARTADO,05045
+Colombia-Antioquia-Arboletes,municipality,Colombia,Antioquia,Arboletes,NA,ANTIOQUIA,ARBOLETES,05051
+Colombia-Antioquia-Argelia,municipality,Colombia,Antioquia,Argelia,NA,ANTIOQUIA,ARGELIA,05055
+Colombia-Antioquia-Armenia,municipality,Colombia,Antioquia,Armenia,NA,ANTIOQUIA,ARMENIA,05059
+Colombia-Antioquia-Barbosa,municipality,Colombia,Antioquia,Barbosa,NA,ANTIOQUIA,BARBOSA,05079
+Colombia-Antioquia-Belmira,municipality,Colombia,Antioquia,Belmira,NA,ANTIOQUIA,BELMIRA,05086
+Colombia-Antioquia-Bello,municipality,Colombia,Antioquia,Bello,NA,ANTIOQUIA,BELLO,05088
+Colombia-Antioquia-Betania,municipality,Colombia,Antioquia,Betania,NA,ANTIOQUIA,BETANIA,05091
+Colombia-Antioquia-Betulia,municipality,Colombia,Antioquia,Betulia,NA,ANTIOQUIA,BETULIA,05093
+Colombia-Antioquia-Ciudad_Bolivar,municipality,Colombia,Antioquia,Ciudad_Bolivar,NA,ANTIOQUIA,CIUDAD BOLIVAR,05101
+Colombia-Antioquia-Briceno,municipality,Colombia,Antioquia,Briceno,NA,ANTIOQUIA,BRICEÑO,05107
+Colombia-Antioquia-Buritica,municipality,Colombia,Antioquia,Buritica,NA,ANTIOQUIA,BURITICA,05113
+Colombia-Antioquia-Caceres,municipality,Colombia,Antioquia,Caceres,NA,ANTIOQUIA,CACERES,05120
+Colombia-Antioquia-Caicedo,municipality,Colombia,Antioquia,Caicedo,NA,ANTIOQUIA,CAICEDO,05125
+Colombia-Antioquia-Caldas,municipality,Colombia,Antioquia,Caldas,NA,ANTIOQUIA,CALDAS,05129
+Colombia-Antioquia-Campamento,municipality,Colombia,Antioquia,Campamento,NA,ANTIOQUIA,CAMPAMENTO,05134
+Colombia-Antioquia-Canasgordas,municipality,Colombia,Antioquia,Canasgordas,NA,ANTIOQUIA,CAÑASGORDAS,05138
+Colombia-Antioquia-Caracoli,municipality,Colombia,Antioquia,Caracoli,NA,ANTIOQUIA,CARACOLI,05142
+Colombia-Antioquia-Caramanta,municipality,Colombia,Antioquia,Caramanta,NA,ANTIOQUIA,CARAMANTA,05145
+Colombia-Antioquia-Carepa,municipality,Colombia,Antioquia,Carepa,NA,ANTIOQUIA,CAREPA,05147
+Colombia-Antioquia-El_Carmen_De_Viboral,municipality,Colombia,Antioquia,El_Carmen_De_Viboral,NA,ANTIOQUIA,EL CARMEN DE VIBORAL,05148
+Colombia-Antioquia-Carolina,municipality,Colombia,Antioquia,Carolina,NA,ANTIOQUIA,CAROLINA,05150
+Colombia-Antioquia-Caucasia,municipality,Colombia,Antioquia,Caucasia,NA,ANTIOQUIA,CAUCASIA,05154
+Colombia-Antioquia-Chigorodo,municipality,Colombia,Antioquia,Chigorodo,NA,ANTIOQUIA,CHIGORODO,05172
+Colombia-Antioquia-Cisneros,municipality,Colombia,Antioquia,Cisneros,NA,ANTIOQUIA,CISNEROS,05190
+Colombia-Antioquia-Cocorna,municipality,Colombia,Antioquia,Cocorna,NA,ANTIOQUIA,COCORNA,05197
+Colombia-Antioquia-Concepcion,municipality,Colombia,Antioquia,Concepcion,NA,ANTIOQUIA,CONCEPCION,05206
+Colombia-Antioquia-Concordia,municipality,Colombia,Antioquia,Concordia,NA,ANTIOQUIA,CONCORDIA,05209
+Colombia-Antioquia-Copacabana,municipality,Colombia,Antioquia,Copacabana,NA,ANTIOQUIA,COPACABANA,05212
+Colombia-Antioquia-Dabeiba,municipality,Colombia,Antioquia,Dabeiba,NA,ANTIOQUIA,DABEIBA,05234
+Colombia-Antioquia-Don_Matias,municipality,Colombia,Antioquia,Don_Matias,NA,ANTIOQUIA,DON MATIAS,05237
+Colombia-Antioquia-Ebejico,municipality,Colombia,Antioquia,Ebejico,NA,ANTIOQUIA,EBEJICO,05240
+Colombia-Antioquia-El_Bagre,municipality,Colombia,Antioquia,El_Bagre,NA,ANTIOQUIA,EL BAGRE,05250
+Colombia-Antioquia-Entrerrios,municipality,Colombia,Antioquia,Entrerrios,NA,ANTIOQUIA,ENTRERRIOS,05264
+Colombia-Antioquia-Envigado,municipality,Colombia,Antioquia,Envigado,NA,ANTIOQUIA,ENVIGADO,05266
+Colombia-Antioquia-Fredonia,municipality,Colombia,Antioquia,Fredonia,NA,ANTIOQUIA,FREDONIA,05282
+Colombia-Antioquia-Frontino,municipality,Colombia,Antioquia,Frontino,NA,ANTIOQUIA,FRONTINO,05284
+Colombia-Antioquia-Giraldo,municipality,Colombia,Antioquia,Giraldo,NA,ANTIOQUIA,GIRALDO,05306
+Colombia-Antioquia-Girardota,municipality,Colombia,Antioquia,Girardota,NA,ANTIOQUIA,GIRARDOTA,05308
+Colombia-Antioquia-Gomez_Plata,municipality,Colombia,Antioquia,Gomez_Plata,NA,ANTIOQUIA,GOMEZ PLATA,05310
+Colombia-Antioquia-Granada,municipality,Colombia,Antioquia,Granada,NA,ANTIOQUIA,GRANADA,05313
+Colombia-Antioquia-Guadalupe,municipality,Colombia,Antioquia,Guadalupe,NA,ANTIOQUIA,GUADALUPE,05315
+Colombia-Antioquia-Guarne,municipality,Colombia,Antioquia,Guarne,NA,ANTIOQUIA,GUARNE,05318
+Colombia-Antioquia-Guatape,municipality,Colombia,Antioquia,Guatape,NA,ANTIOQUIA,GUATAPE,05321
+Colombia-Antioquia-Heliconia,municipality,Colombia,Antioquia,Heliconia,NA,ANTIOQUIA,HELICONIA,05347
+Colombia-Antioquia-Hispania,municipality,Colombia,Antioquia,Hispania,NA,ANTIOQUIA,HISPANIA,05353
+Colombia-Antioquia-Itagui,municipality,Colombia,Antioquia,Itagui,NA,ANTIOQUIA,ITAGUI,05360
+Colombia-Antioquia-Ituango,municipality,Colombia,Antioquia,Ituango,NA,ANTIOQUIA,ITUANGO,05361
+Colombia-Antioquia-Jardin,municipality,Colombia,Antioquia,Jardin,NA,ANTIOQUIA,JARDIN,05364
+Colombia-Antioquia-Jerico,municipality,Colombia,Antioquia,Jerico,NA,ANTIOQUIA,JERICO,05368
+Colombia-Antioquia-La_Ceja,municipality,Colombia,Antioquia,La_Ceja,NA,ANTIOQUIA,LA CEJA,05376
+Colombia-Antioquia-La_Estrella,municipality,Colombia,Antioquia,La_Estrella,NA,ANTIOQUIA,LA ESTRELLA,05380
+Colombia-Antioquia-La_Pintada,municipality,Colombia,Antioquia,La_Pintada,NA,ANTIOQUIA,LA PINTADA,05390
+Colombia-Antioquia-La_Union,municipality,Colombia,Antioquia,La_Union,NA,ANTIOQUIA,LA UNION,05400
+Colombia-Antioquia-Liborina,municipality,Colombia,Antioquia,Liborina,NA,ANTIOQUIA,LIBORINA,05411
+Colombia-Antioquia-Maceo,municipality,Colombia,Antioquia,Maceo,NA,ANTIOQUIA,MACEO,05425
+Colombia-Antioquia-Marinilla,municipality,Colombia,Antioquia,Marinilla,NA,ANTIOQUIA,MARINILLA,05440
+Colombia-Antioquia-Montebello,municipality,Colombia,Antioquia,Montebello,NA,ANTIOQUIA,MONTEBELLO,05467
+Colombia-Antioquia-Murindo,municipality,Colombia,Antioquia,Murindo,NA,ANTIOQUIA,MURINDO,05475
+Colombia-Antioquia-Mutata,municipality,Colombia,Antioquia,Mutata,NA,ANTIOQUIA,MUTATA,05480
+Colombia-Antioquia-Narino,municipality,Colombia,Antioquia,Narino,NA,ANTIOQUIA,NARIÑO,05483
+Colombia-Antioquia-Necocli,municipality,Colombia,Antioquia,Necocli,NA,ANTIOQUIA,NECOCLI,05490
+Colombia-Antioquia-Nechi,municipality,Colombia,Antioquia,Nechi,NA,ANTIOQUIA,NECHI,05495
+Colombia-Antioquia-Olaya,municipality,Colombia,Antioquia,Olaya,NA,ANTIOQUIA,OLAYA,05501
+Colombia-Antioquia-Peðol,municipality,Colombia,Antioquia,Peðol,NA,ANTIOQUIA,PEÐOL,05541
+Colombia-Antioquia-Peque,municipality,Colombia,Antioquia,Peque,NA,ANTIOQUIA,PEQUE,05543
+Colombia-Antioquia-Pueblorrico,municipality,Colombia,Antioquia,Pueblorrico,NA,ANTIOQUIA,PUEBLORRICO,05576
+Colombia-Antioquia-Puerto_Berrio,municipality,Colombia,Antioquia,Puerto_Berrio,NA,ANTIOQUIA,PUERTO BERRIO,05579
+Colombia-Antioquia-Puerto_Nare,municipality,Colombia,Antioquia,Puerto_Nare,NA,ANTIOQUIA,PUERTO NARE,05585
+Colombia-Antioquia-Puerto_Triunfo,municipality,Colombia,Antioquia,Puerto_Triunfo,NA,ANTIOQUIA,PUERTO TRIUNFO,05591
+Colombia-Antioquia-Remedios,municipality,Colombia,Antioquia,Remedios,NA,ANTIOQUIA,REMEDIOS,05604
+Colombia-Antioquia-Retiro,municipality,Colombia,Antioquia,Retiro,NA,ANTIOQUIA,RETIRO,05607
+Colombia-Antioquia-Rionegro,municipality,Colombia,Antioquia,Rionegro,NA,ANTIOQUIA,RIONEGRO,05615
+Colombia-Antioquia-Sabanalarga,municipality,Colombia,Antioquia,Sabanalarga,NA,ANTIOQUIA,SABANALARGA,05628
+Colombia-Antioquia-Sabaneta,municipality,Colombia,Antioquia,Sabaneta,NA,ANTIOQUIA,SABANETA,05631
+Colombia-Antioquia-Salgar,municipality,Colombia,Antioquia,Salgar,NA,ANTIOQUIA,SALGAR,05642
+Colombia-Antioquia-San_Andres_De_Cuerquia,municipality,Colombia,Antioquia,San_Andres_De_Cuerquia,NA,ANTIOQUIA,SAN ANDRES DE CUERQUIA,05647
+Colombia-Antioquia-San_Carlos,municipality,Colombia,Antioquia,San_Carlos,NA,ANTIOQUIA,SAN CARLOS,05649
+Colombia-Antioquia-San_Francisco,municipality,Colombia,Antioquia,San_Francisco,NA,ANTIOQUIA,SAN FRANCISCO,05652
+Colombia-Antioquia-San_Jeronimo,municipality,Colombia,Antioquia,San_Jeronimo,NA,ANTIOQUIA,SAN JERONIMO,05656
+Colombia-Antioquia-San_Jose_De_La_Montana,municipality,Colombia,Antioquia,San_Jose_De_La_Montana,NA,ANTIOQUIA,SAN JOSE DE LA MONTAÑA,05658
+Colombia-Antioquia-San_Juan_De_Uraba,municipality,Colombia,Antioquia,San_Juan_De_Uraba,NA,ANTIOQUIA,SAN JUAN DE URABA,05659
+Colombia-Antioquia-San_Luis,municipality,Colombia,Antioquia,San_Luis,NA,ANTIOQUIA,SAN LUIS,05660
+Colombia-Antioquia-San_Pedro,municipality,Colombia,Antioquia,San_Pedro,NA,ANTIOQUIA,SAN PEDRO,05664
+Colombia-Antioquia-San_Pedro_De_Uraba,municipality,Colombia,Antioquia,San_Pedro_De_Uraba,NA,ANTIOQUIA,SAN PEDRO DE URABA,05665
+Colombia-Antioquia-San_Rafael,municipality,Colombia,Antioquia,San_Rafael,NA,ANTIOQUIA,SAN RAFAEL,05667
+Colombia-Antioquia-San_Roque,municipality,Colombia,Antioquia,San_Roque,NA,ANTIOQUIA,SAN ROQUE,05670
+Colombia-Antioquia-San_Vicente,municipality,Colombia,Antioquia,San_Vicente,NA,ANTIOQUIA,SAN VICENTE,05674
+Colombia-Antioquia-Santa_Barbara,municipality,Colombia,Antioquia,Santa_Barbara,NA,ANTIOQUIA,SANTA BARBARA,05679
+Colombia-Antioquia-Santa_Rosa_De_Osos,municipality,Colombia,Antioquia,Santa_Rosa_De_Osos,NA,ANTIOQUIA,SANTA ROSA DE OSOS,05686
+Colombia-Antioquia-Santo_Domingo,municipality,Colombia,Antioquia,Santo_Domingo,NA,ANTIOQUIA,SANTO DOMINGO,05690
+Colombia-Antioquia-El_Santuario,municipality,Colombia,Antioquia,El_Santuario,NA,ANTIOQUIA,EL SANTUARIO,05697
+Colombia-Antioquia-Segovia,municipality,Colombia,Antioquia,Segovia,NA,ANTIOQUIA,SEGOVIA,05736
+Colombia-Antioquia-Sonson,municipality,Colombia,Antioquia,Sonson,NA,ANTIOQUIA,SONSON,05756
+Colombia-Antioquia-Sopetran,municipality,Colombia,Antioquia,Sopetran,NA,ANTIOQUIA,SOPETRAN,05761
+Colombia-Antioquia-Tamesis,municipality,Colombia,Antioquia,Tamesis,NA,ANTIOQUIA,TAMESIS,05789
+Colombia-Antioquia-Taraza,municipality,Colombia,Antioquia,Taraza,NA,ANTIOQUIA,TARAZA,05790
+Colombia-Antioquia-Tarso,municipality,Colombia,Antioquia,Tarso,NA,ANTIOQUIA,TARSO,05792
+Colombia-Antioquia-Titiribi,municipality,Colombia,Antioquia,Titiribi,NA,ANTIOQUIA,TITIRIBI,05809
+Colombia-Antioquia-Toledo,municipality,Colombia,Antioquia,Toledo,NA,ANTIOQUIA,TOLEDO,05819
+Colombia-Antioquia-Turbo,municipality,Colombia,Antioquia,Turbo,NA,ANTIOQUIA,TURBO,05837
+Colombia-Antioquia-Uramita,municipality,Colombia,Antioquia,Uramita,NA,ANTIOQUIA,URAMITA,05842
+Colombia-Antioquia-Urrao,municipality,Colombia,Antioquia,Urrao,NA,ANTIOQUIA,URRAO,05847
+Colombia-Antioquia-Valdivia,municipality,Colombia,Antioquia,Valdivia,NA,ANTIOQUIA,VALDIVIA,05854
+Colombia-Antioquia-Valparaiso,municipality,Colombia,Antioquia,Valparaiso,NA,ANTIOQUIA,VALPARAISO,05856
+Colombia-Antioquia-Vegachi,municipality,Colombia,Antioquia,Vegachi,NA,ANTIOQUIA,VEGACHI,05858
+Colombia-Antioquia-Venecia,municipality,Colombia,Antioquia,Venecia,NA,ANTIOQUIA,VENECIA,05861
+Colombia-Antioquia-Vigia_Del_Fuerte,municipality,Colombia,Antioquia,Vigia_Del_Fuerte,NA,ANTIOQUIA,VIGIA DEL FUERTE,05873
+Colombia-Antioquia-Yali,municipality,Colombia,Antioquia,Yali,NA,ANTIOQUIA,YALI,05885
+Colombia-Antioquia-Yarumal,municipality,Colombia,Antioquia,Yarumal,NA,ANTIOQUIA,YARUMAL,05887
+Colombia-Antioquia-Yolombo,municipality,Colombia,Antioquia,Yolombo,NA,ANTIOQUIA,YOLOMBO,05890
+Colombia-Antioquia-Yondo,municipality,Colombia,Antioquia,Yondo,NA,ANTIOQUIA,YONDO,05893
+Colombia-Antioquia-Zaragoza,municipality,Colombia,Antioquia,Zaragoza,NA,ANTIOQUIA,ZARAGOZA,05895
+Colombia-Barranquilla-Barranquilla,municipality,Colombia,Barranquilla,Barranquilla,NA,BARRANQUILLA,BARRANQUILLA,09001
+Colombia-Atlantico-Unknown,municipality,Colombia,Atlantico,Unknown,NA,ATLANTICO,* ATLANTICO. MUNICIPIO DESCONOCIDO,08000
+Colombia-Atlantico-Baranoa,municipality,Colombia,Atlantico,Baranoa,NA,ATLANTICO,BARANOA,08078
+Colombia-Atlantico-Campo_De_La_Cruz,municipality,Colombia,Atlantico,Campo_De_La_Cruz,NA,ATLANTICO,CAMPO DE LA CRUZ,08137
+Colombia-Atlantico-Candelaria,municipality,Colombia,Atlantico,Candelaria,NA,ATLANTICO,CANDELARIA,08141
+Colombia-Atlantico-Galapa,municipality,Colombia,Atlantico,Galapa,NA,ATLANTICO,GALAPA,08296
+Colombia-Atlantico-Juan_De_Acosta,municipality,Colombia,Atlantico,Juan_De_Acosta,NA,ATLANTICO,JUAN DE ACOSTA,08372
+Colombia-Atlantico-Luruaco,municipality,Colombia,Atlantico,Luruaco,NA,ATLANTICO,LURUACO,08421
+Colombia-Atlantico-Malambo,municipality,Colombia,Atlantico,Malambo,NA,ATLANTICO,MALAMBO,08433
+Colombia-Atlantico-Manati,municipality,Colombia,Atlantico,Manati,NA,ATLANTICO,MANATI,08436
+Colombia-Atlantico-Palmar_De_Varela,municipality,Colombia,Atlantico,Palmar_De_Varela,NA,ATLANTICO,PALMAR DE VARELA,08520
+Colombia-Atlantico-Piojo,municipality,Colombia,Atlantico,Piojo,NA,ATLANTICO,PIOJO,08549
+Colombia-Atlantico-Polonuevo,municipality,Colombia,Atlantico,Polonuevo,NA,ATLANTICO,POLONUEVO,08558
+Colombia-Atlantico-Ponedera,municipality,Colombia,Atlantico,Ponedera,NA,ATLANTICO,PONEDERA,08560
+Colombia-Atlantico-Puerto_Colombia,municipality,Colombia,Atlantico,Puerto_Colombia,NA,ATLANTICO,PUERTO COLOMBIA,08573
+Colombia-Atlantico-Repelon,municipality,Colombia,Atlantico,Repelon,NA,ATLANTICO,REPELON,08606
+Colombia-Atlantico-Sabanagrande,municipality,Colombia,Atlantico,Sabanagrande,NA,ATLANTICO,SABANAGRANDE,08634
+Colombia-Atlantico-Sabanalarga,municipality,Colombia,Atlantico,Sabanalarga,NA,ATLANTICO,SABANALARGA,08638
+Colombia-Atlantico-Santa_Lucia,municipality,Colombia,Atlantico,Santa_Lucia,NA,ATLANTICO,SANTA LUCIA,08675
+Colombia-Atlantico-Santo_Tomas,municipality,Colombia,Atlantico,Santo_Tomas,NA,ATLANTICO,SANTO TOMAS,08685
+Colombia-Atlantico-Soledad,municipality,Colombia,Atlantico,Soledad,NA,ATLANTICO,SOLEDAD,08758
+Colombia-Atlantico-Suan,municipality,Colombia,Atlantico,Suan,NA,ATLANTICO,SUAN,08770
+Colombia-Atlantico-Tubara,municipality,Colombia,Atlantico,Tubara,NA,ATLANTICO,TUBARA,08832
+Colombia-Atlantico-Usiacuri,municipality,Colombia,Atlantico,Usiacuri,NA,ATLANTICO,USIACURI,08849
+Colombia-Desconocido-Desconocido,municipality,Colombia,Desconocido,Desconocido,NA,DESCONOCIDO,DESCONOCIDO,11001
+Colombia-Cartagena-Cartagena,municipality,Colombia,Cartagena,Cartagena,NA,CARTAGENA,CARTAGENA,14001
+Colombia-Bolivar-Unknown,municipality,Colombia,Bolivar,Unknown,NA,BOLIVAR,* BOLIVAR. MUNICIPIO DESCONOCIDO,13000
+Colombia-Bolivar-Achi,municipality,Colombia,Bolivar,Achi,NA,BOLIVAR,ACHI,13006
+Colombia-Bolivar-Altos_Del_Rosario,municipality,Colombia,Bolivar,Altos_Del_Rosario,NA,BOLIVAR,ALTOS DEL ROSARIO,13030
+Colombia-Bolivar-Arenal,municipality,Colombia,Bolivar,Arenal,NA,BOLIVAR,ARENAL,13042
+Colombia-Bolivar-Arjona,municipality,Colombia,Bolivar,Arjona,NA,BOLIVAR,ARJONA,13052
+Colombia-Bolivar-Arroyohondo,municipality,Colombia,Bolivar,Arroyohondo,NA,BOLIVAR,ARROYOHONDO,13062
+Colombia-Bolivar-Barranco_De_Loba,municipality,Colombia,Bolivar,Barranco_De_Loba,NA,BOLIVAR,BARRANCO DE LOBA,13074
+Colombia-Bolivar-Calamar,municipality,Colombia,Bolivar,Calamar,NA,BOLIVAR,CALAMAR,13140
+Colombia-Bolivar-Cantagallo,municipality,Colombia,Bolivar,Cantagallo,NA,BOLIVAR,CANTAGALLO,13160
+Colombia-Bolivar-Cicuco,municipality,Colombia,Bolivar,Cicuco,NA,BOLIVAR,CICUCO,13188
+Colombia-Bolivar-Cordoba,municipality,Colombia,Bolivar,Cordoba,NA,BOLIVAR,CORDOBA,13212
+Colombia-Bolivar-Clemencia,municipality,Colombia,Bolivar,Clemencia,NA,BOLIVAR,CLEMENCIA,13222
+Colombia-Bolivar-El_Carmen_De_Bolivar,municipality,Colombia,Bolivar,El_Carmen_De_Bolivar,NA,BOLIVAR,EL CARMEN DE BOLIVAR,13244
+Colombia-Bolivar-El_Guamo,municipality,Colombia,Bolivar,El_Guamo,NA,BOLIVAR,EL GUAMO,13248
+Colombia-Bolivar-El_Penon,municipality,Colombia,Bolivar,El_Penon,NA,BOLIVAR,EL PEÑON,13268
+Colombia-Bolivar-Hatillo_De_Loba,municipality,Colombia,Bolivar,Hatillo_De_Loba,NA,BOLIVAR,HATILLO DE LOBA,13300
+Colombia-Bolivar-Magangue,municipality,Colombia,Bolivar,Magangue,NA,BOLIVAR,MAGANGUE,13430
+Colombia-Bolivar-Mahates,municipality,Colombia,Bolivar,Mahates,NA,BOLIVAR,MAHATES,13433
+Colombia-Bolivar-Margarita,municipality,Colombia,Bolivar,Margarita,NA,BOLIVAR,MARGARITA,13440
+Colombia-Bolivar-Maria_La_Baja,municipality,Colombia,Bolivar,Maria_La_Baja,NA,BOLIVAR,MARIA LA BAJA,13442
+Colombia-Bolivar-Montecristo,municipality,Colombia,Bolivar,Montecristo,NA,BOLIVAR,MONTECRISTO,13458
+Colombia-Bolivar-Mompos,municipality,Colombia,Bolivar,Mompos,NA,BOLIVAR,MOMPOS,13468
+Colombia-Bolivar-Norosi,municipality,Colombia,Bolivar,Norosi,NA,BOLIVAR,NOROSI,13490
+Colombia-Bolivar-Morales,municipality,Colombia,Bolivar,Morales,NA,BOLIVAR,MORALES,13473
+Colombia-Bolivar-Pinillos,municipality,Colombia,Bolivar,Pinillos,NA,BOLIVAR,PINILLOS,13549
+Colombia-Bolivar-Regidor,municipality,Colombia,Bolivar,Regidor,NA,BOLIVAR,REGIDOR,13580
+Colombia-Bolivar-Rio_Viejo,municipality,Colombia,Bolivar,Rio_Viejo,NA,BOLIVAR,RIO VIEJO,13600
+Colombia-Bolivar-San_Cristobal,municipality,Colombia,Bolivar,San_Cristobal,NA,BOLIVAR,SAN CRISTOBAL,13620
+Colombia-Bolivar-San_Estanislao,municipality,Colombia,Bolivar,San_Estanislao,NA,BOLIVAR,SAN ESTANISLAO,13647
+Colombia-Bolivar-San_Fernando,municipality,Colombia,Bolivar,San_Fernando,NA,BOLIVAR,SAN FERNANDO,13650
+Colombia-Bolivar-San_Jacinto,municipality,Colombia,Bolivar,San_Jacinto,NA,BOLIVAR,SAN JACINTO,13654
+Colombia-Bolivar-San_Jacinto_Del_Cauca,municipality,Colombia,Bolivar,San_Jacinto_Del_Cauca,NA,BOLIVAR,SAN JACINTO DEL CAUCA,13655
+Colombia-Bolivar-San_Juan_Nepomuceno,municipality,Colombia,Bolivar,San_Juan_Nepomuceno,NA,BOLIVAR,SAN JUAN NEPOMUCENO,13657
+Colombia-Bolivar-San_Martin_De_Loba,municipality,Colombia,Bolivar,San_Martin_De_Loba,NA,BOLIVAR,SAN MARTIN DE LOBA,13667
+Colombia-Bolivar-San_Pablo,municipality,Colombia,Bolivar,San_Pablo,NA,BOLIVAR,SAN PABLO,13670
+Colombia-Bolivar-Santa_Catalina,municipality,Colombia,Bolivar,Santa_Catalina,NA,BOLIVAR,SANTA CATALINA,13673
+Colombia-Bolivar-Santa_Rosa,municipality,Colombia,Bolivar,Santa_Rosa,NA,BOLIVAR,SANTA ROSA,13683
+Colombia-Bolivar-Santa_Rosa_Del_Sur,municipality,Colombia,Bolivar,Santa_Rosa_Del_Sur,NA,BOLIVAR,SANTA ROSA DEL SUR,13688
+Colombia-Bolivar-Simiti,municipality,Colombia,Bolivar,Simiti,NA,BOLIVAR,SIMITI,13744
+Colombia-Bolivar-Soplaviento,municipality,Colombia,Bolivar,Soplaviento,NA,BOLIVAR,SOPLAVIENTO,13760
+Colombia-Bolivar-Talaigua_Nuevo,municipality,Colombia,Bolivar,Talaigua_Nuevo,NA,BOLIVAR,TALAIGUA NUEVO,13780
+Colombia-Bolivar-Tiquisio,municipality,Colombia,Bolivar,Tiquisio,NA,BOLIVAR,TIQUISIO,13810
+Colombia-Bolivar-Turbaco,municipality,Colombia,Bolivar,Turbaco,NA,BOLIVAR,TURBACO,13836
+Colombia-Bolivar-Turbana,municipality,Colombia,Bolivar,Turbana,NA,BOLIVAR,TURBANA,13838
+Colombia-Bolivar-Villanueva,municipality,Colombia,Bolivar,Villanueva,NA,BOLIVAR,VILLANUEVA,13873
+Colombia-Bolivar-Zambrano,municipality,Colombia,Bolivar,Zambrano,NA,BOLIVAR,ZAMBRANO,13894
+Colombia-Boyaca-Unknown,municipality,Colombia,Boyaca,Unknown,NA,BOYACA,* BOYACA. MUNICIPIO DESCONOCIDO,15000
+Colombia-Boyaca-Tunja,municipality,Colombia,Boyaca,Tunja,NA,BOYACA,TUNJA,15001
+Colombia-Boyaca-Almeida,municipality,Colombia,Boyaca,Almeida,NA,BOYACA,ALMEIDA,15022
+Colombia-Boyaca-Aquitania,municipality,Colombia,Boyaca,Aquitania,NA,BOYACA,AQUITANIA,15047
+Colombia-Boyaca-Arcabuco,municipality,Colombia,Boyaca,Arcabuco,NA,BOYACA,ARCABUCO,15051
+Colombia-Boyaca-Belen,municipality,Colombia,Boyaca,Belen,NA,BOYACA,BELEN,15087
+Colombia-Boyaca-Berbeo,municipality,Colombia,Boyaca,Berbeo,NA,BOYACA,BERBEO,15090
+Colombia-Boyaca-Beteitiva,municipality,Colombia,Boyaca,Beteitiva,NA,BOYACA,BETEITIVA,15092
+Colombia-Boyaca-Boavita,municipality,Colombia,Boyaca,Boavita,NA,BOYACA,BOAVITA,15097
+Colombia-Boyaca-Boyaca,municipality,Colombia,Boyaca,Boyaca,NA,BOYACA,BOYACA,15104
+Colombia-Boyaca-Briceno,municipality,Colombia,Boyaca,Briceno,NA,BOYACA,BRICEÑO,15106
+Colombia-Boyaca-Buenavista,municipality,Colombia,Boyaca,Buenavista,NA,BOYACA,BUENAVISTA,15109
+Colombia-Boyaca-Busbanza,municipality,Colombia,Boyaca,Busbanza,NA,BOYACA,BUSBANZA,15114
+Colombia-Boyaca-Caldas,municipality,Colombia,Boyaca,Caldas,NA,BOYACA,CALDAS,15131
+Colombia-Boyaca-Campohermoso,municipality,Colombia,Boyaca,Campohermoso,NA,BOYACA,CAMPOHERMOSO,15135
+Colombia-Boyaca-Cerinza,municipality,Colombia,Boyaca,Cerinza,NA,BOYACA,CERINZA,15162
+Colombia-Boyaca-Chinavita,municipality,Colombia,Boyaca,Chinavita,NA,BOYACA,CHINAVITA,15172
+Colombia-Boyaca-Chiquinquira,municipality,Colombia,Boyaca,Chiquinquira,NA,BOYACA,CHIQUINQUIRA,15176
+Colombia-Boyaca-Chiscas,municipality,Colombia,Boyaca,Chiscas,NA,BOYACA,CHISCAS,15180
+Colombia-Boyaca-Chita,municipality,Colombia,Boyaca,Chita,NA,BOYACA,CHITA,15183
+Colombia-Boyaca-Chitaraque,municipality,Colombia,Boyaca,Chitaraque,NA,BOYACA,CHITARAQUE,15185
+Colombia-Boyaca-Chivata,municipality,Colombia,Boyaca,Chivata,NA,BOYACA,CHIVATA,15187
+Colombia-Boyaca-Cienega,municipality,Colombia,Boyaca,Cienega,NA,BOYACA,CIENEGA,15189
+Colombia-Boyaca-Combita,municipality,Colombia,Boyaca,Combita,NA,BOYACA,COMBITA,15204
+Colombia-Boyaca-Coper,municipality,Colombia,Boyaca,Coper,NA,BOYACA,COPER,15212
+Colombia-Boyaca-Corrales,municipality,Colombia,Boyaca,Corrales,NA,BOYACA,CORRALES,15215
+Colombia-Boyaca-Covarachia,municipality,Colombia,Boyaca,Covarachia,NA,BOYACA,COVARACHIA,15218
+Colombia-Boyaca-Cubara,municipality,Colombia,Boyaca,Cubara,NA,BOYACA,CUBARA,15223
+Colombia-Boyaca-Cucaita,municipality,Colombia,Boyaca,Cucaita,NA,BOYACA,CUCAITA,15224
+Colombia-Boyaca-Cuitiva,municipality,Colombia,Boyaca,Cuitiva,NA,BOYACA,CUITIVA,15226
+Colombia-Boyaca-Chiquiza,municipality,Colombia,Boyaca,Chiquiza,NA,BOYACA,CHIQUIZA,15232
+Colombia-Boyaca-Chivor,municipality,Colombia,Boyaca,Chivor,NA,BOYACA,CHIVOR,15236
+Colombia-Boyaca-Duitama,municipality,Colombia,Boyaca,Duitama,NA,BOYACA,DUITAMA,15238
+Colombia-Boyaca-El_Cocuy,municipality,Colombia,Boyaca,El_Cocuy,NA,BOYACA,EL COCUY,15244
+Colombia-Boyaca-El_Espino,municipality,Colombia,Boyaca,El_Espino,NA,BOYACA,EL ESPINO,15248
+Colombia-Boyaca-Firavitoba,municipality,Colombia,Boyaca,Firavitoba,NA,BOYACA,FIRAVITOBA,15272
+Colombia-Boyaca-Floresta,municipality,Colombia,Boyaca,Floresta,NA,BOYACA,FLORESTA,15276
+Colombia-Boyaca-Gachantiva,municipality,Colombia,Boyaca,Gachantiva,NA,BOYACA,GACHANTIVA,15293
+Colombia-Boyaca-Gameza,municipality,Colombia,Boyaca,Gameza,NA,BOYACA,GAMEZA,15296
+Colombia-Boyaca-Garagoa,municipality,Colombia,Boyaca,Garagoa,NA,BOYACA,GARAGOA,15299
+Colombia-Boyaca-Guacamayas,municipality,Colombia,Boyaca,Guacamayas,NA,BOYACA,GUACAMAYAS,15317
+Colombia-Boyaca-Guateque,municipality,Colombia,Boyaca,Guateque,NA,BOYACA,GUATEQUE,15322
+Colombia-Boyaca-Guayata,municipality,Colombia,Boyaca,Guayata,NA,BOYACA,GUAYATA,15325
+Colombia-Boyaca-Guican,municipality,Colombia,Boyaca,Guican,NA,BOYACA,GUICAN,15332
+Colombia-Boyaca-Iza,municipality,Colombia,Boyaca,Iza,NA,BOYACA,IZA,15362
+Colombia-Boyaca-Jenesano,municipality,Colombia,Boyaca,Jenesano,NA,BOYACA,JENESANO,15367
+Colombia-Boyaca-Jerico,municipality,Colombia,Boyaca,Jerico,NA,BOYACA,JERICO,15368
+Colombia-Boyaca-Labranzagrande,municipality,Colombia,Boyaca,Labranzagrande,NA,BOYACA,LABRANZAGRANDE,15377
+Colombia-Boyaca-La_Capilla,municipality,Colombia,Boyaca,La_Capilla,NA,BOYACA,LA CAPILLA,15380
+Colombia-Boyaca-La_Victoria,municipality,Colombia,Boyaca,La_Victoria,NA,BOYACA,LA VICTORIA,15401
+Colombia-Boyaca-La_Uvita,municipality,Colombia,Boyaca,La_Uvita,NA,BOYACA,LA UVITA,15403
+Colombia-Boyaca-Villa_De_Leyva,municipality,Colombia,Boyaca,Villa_De_Leyva,NA,BOYACA,VILLA DE LEYVA,15407
+Colombia-Boyaca-Macanal,municipality,Colombia,Boyaca,Macanal,NA,BOYACA,MACANAL,15425
+Colombia-Boyaca-Maripi,municipality,Colombia,Boyaca,Maripi,NA,BOYACA,MARIPI,15442
+Colombia-Boyaca-Miraflores,municipality,Colombia,Boyaca,Miraflores,NA,BOYACA,MIRAFLORES,15455
+Colombia-Boyaca-Mongua,municipality,Colombia,Boyaca,Mongua,NA,BOYACA,MONGUA,15464
+Colombia-Boyaca-Mongui,municipality,Colombia,Boyaca,Mongui,NA,BOYACA,MONGUI,15466
+Colombia-Boyaca-Moniquira,municipality,Colombia,Boyaca,Moniquira,NA,BOYACA,MONIQUIRA,15469
+Colombia-Boyaca-Motavita,municipality,Colombia,Boyaca,Motavita,NA,BOYACA,MOTAVITA,15476
+Colombia-Boyaca-Muzo,municipality,Colombia,Boyaca,Muzo,NA,BOYACA,MUZO,15480
+Colombia-Boyaca-Nobsa,municipality,Colombia,Boyaca,Nobsa,NA,BOYACA,NOBSA,15491
+Colombia-Boyaca-Nuevo_Colon,municipality,Colombia,Boyaca,Nuevo_Colon,NA,BOYACA,NUEVO COLON,15494
+Colombia-Boyaca-Oicata,municipality,Colombia,Boyaca,Oicata,NA,BOYACA,OICATA,15500
+Colombia-Boyaca-Otanche,municipality,Colombia,Boyaca,Otanche,NA,BOYACA,OTANCHE,15507
+Colombia-Boyaca-Pachavita,municipality,Colombia,Boyaca,Pachavita,NA,BOYACA,PACHAVITA,15511
+Colombia-Boyaca-Paez,municipality,Colombia,Boyaca,Paez,NA,BOYACA,PAEZ,15514
+Colombia-Boyaca-Paipa,municipality,Colombia,Boyaca,Paipa,NA,BOYACA,PAIPA,15516
+Colombia-Boyaca-Pajarito,municipality,Colombia,Boyaca,Pajarito,NA,BOYACA,PAJARITO,15518
+Colombia-Boyaca-Panqueba,municipality,Colombia,Boyaca,Panqueba,NA,BOYACA,PANQUEBA,15522
+Colombia-Boyaca-Pauna,municipality,Colombia,Boyaca,Pauna,NA,BOYACA,PAUNA,15531
+Colombia-Boyaca-Paya,municipality,Colombia,Boyaca,Paya,NA,BOYACA,PAYA,15533
+Colombia-Boyaca-Paz_De_Rio,municipality,Colombia,Boyaca,Paz_De_Rio,NA,BOYACA,PAZ DE RIO,15537
+Colombia-Boyaca-Pesca,municipality,Colombia,Boyaca,Pesca,NA,BOYACA,PESCA,15542
+Colombia-Boyaca-Pisba,municipality,Colombia,Boyaca,Pisba,NA,BOYACA,PISBA,15550
+Colombia-Boyaca-Puerto_Boyaca,municipality,Colombia,Boyaca,Puerto_Boyaca,NA,BOYACA,PUERTO BOYACA,15572
+Colombia-Boyaca-Quipama,municipality,Colombia,Boyaca,Quipama,NA,BOYACA,QUIPAMA,15580
+Colombia-Boyaca-Ramiriqui,municipality,Colombia,Boyaca,Ramiriqui,NA,BOYACA,RAMIRIQUI,15599
+Colombia-Boyaca-Raquira,municipality,Colombia,Boyaca,Raquira,NA,BOYACA,RAQUIRA,15600
+Colombia-Boyaca-Rondon,municipality,Colombia,Boyaca,Rondon,NA,BOYACA,RONDON,15621
+Colombia-Boyaca-Saboya,municipality,Colombia,Boyaca,Saboya,NA,BOYACA,SABOYA,15632
+Colombia-Boyaca-Sachica,municipality,Colombia,Boyaca,Sachica,NA,BOYACA,SACHICA,15638
+Colombia-Boyaca-Samaca,municipality,Colombia,Boyaca,Samaca,NA,BOYACA,SAMACA,15646
+Colombia-Boyaca-San_Eduardo,municipality,Colombia,Boyaca,San_Eduardo,NA,BOYACA,SAN EDUARDO,15660
+Colombia-Boyaca-San_Jose_De_Pare,municipality,Colombia,Boyaca,San_Jose_De_Pare,NA,BOYACA,SAN JOSE DE PARE,15664
+Colombia-Boyaca-San_Luis_De_Gaceno,municipality,Colombia,Boyaca,San_Luis_De_Gaceno,NA,BOYACA,SAN LUIS DE GACENO,15667
+Colombia-Boyaca-San_Mateo,municipality,Colombia,Boyaca,San_Mateo,NA,BOYACA,SAN MATEO,15673
+Colombia-Boyaca-San_Miguel_De_Sema,municipality,Colombia,Boyaca,San_Miguel_De_Sema,NA,BOYACA,SAN MIGUEL DE SEMA,15676
+Colombia-Boyaca-San_Pablo_De_Borbur,municipality,Colombia,Boyaca,San_Pablo_De_Borbur,NA,BOYACA,SAN PABLO DE BORBUR,15681
+Colombia-Boyaca-Santana,municipality,Colombia,Boyaca,Santana,NA,BOYACA,SANTANA,15686
+Colombia-Boyaca-Santa_Maria,municipality,Colombia,Boyaca,Santa_Maria,NA,BOYACA,SANTA MARIA,15690
+Colombia-Boyaca-Santa_Rosa_De_Viterbo,municipality,Colombia,Boyaca,Santa_Rosa_De_Viterbo,NA,BOYACA,SANTA ROSA DE VITERBO,15693
+Colombia-Boyaca-Santa_Sofia,municipality,Colombia,Boyaca,Santa_Sofia,NA,BOYACA,SANTA SOFIA,15696
+Colombia-Boyaca-Sativanorte,municipality,Colombia,Boyaca,Sativanorte,NA,BOYACA,SATIVANORTE,15720
+Colombia-Boyaca-Sativasur,municipality,Colombia,Boyaca,Sativasur,NA,BOYACA,SATIVASUR,15723
+Colombia-Boyaca-Siachoque,municipality,Colombia,Boyaca,Siachoque,NA,BOYACA,SIACHOQUE,15740
+Colombia-Boyaca-Soata,municipality,Colombia,Boyaca,Soata,NA,BOYACA,SOATA,15753
+Colombia-Boyaca-Socota,municipality,Colombia,Boyaca,Socota,NA,BOYACA,SOCOTA,15755
+Colombia-Boyaca-Socha,municipality,Colombia,Boyaca,Socha,NA,BOYACA,SOCHA,15757
+Colombia-Boyaca-Sogamoso,municipality,Colombia,Boyaca,Sogamoso,NA,BOYACA,SOGAMOSO,15759
+Colombia-Boyaca-Somondoco,municipality,Colombia,Boyaca,Somondoco,NA,BOYACA,SOMONDOCO,15761
+Colombia-Boyaca-Sora,municipality,Colombia,Boyaca,Sora,NA,BOYACA,SORA,15762
+Colombia-Boyaca-Sotaquira,municipality,Colombia,Boyaca,Sotaquira,NA,BOYACA,SOTAQUIRA,15763
+Colombia-Boyaca-Soraca,municipality,Colombia,Boyaca,Soraca,NA,BOYACA,SORACA,15764
+Colombia-Boyaca-Susacon,municipality,Colombia,Boyaca,Susacon,NA,BOYACA,SUSACON,15774
+Colombia-Boyaca-Sutamarchan,municipality,Colombia,Boyaca,Sutamarchan,NA,BOYACA,SUTAMARCHAN,15776
+Colombia-Boyaca-Sutatenza,municipality,Colombia,Boyaca,Sutatenza,NA,BOYACA,SUTATENZA,15778
+Colombia-Boyaca-Tasco,municipality,Colombia,Boyaca,Tasco,NA,BOYACA,TASCO,15790
+Colombia-Boyaca-Tenza,municipality,Colombia,Boyaca,Tenza,NA,BOYACA,TENZA,15798
+Colombia-Boyaca-Tibana,municipality,Colombia,Boyaca,Tibana,NA,BOYACA,TIBANA,15804
+Colombia-Boyaca-Tibasosa,municipality,Colombia,Boyaca,Tibasosa,NA,BOYACA,TIBASOSA,15806
+Colombia-Boyaca-Tinjaca,municipality,Colombia,Boyaca,Tinjaca,NA,BOYACA,TINJACA,15808
+Colombia-Boyaca-Tipacoque,municipality,Colombia,Boyaca,Tipacoque,NA,BOYACA,TIPACOQUE,15810
+Colombia-Boyaca-Toca,municipality,Colombia,Boyaca,Toca,NA,BOYACA,TOCA,15814
+Colombia-Boyaca-Togui,municipality,Colombia,Boyaca,Togui,NA,BOYACA,TOGUÍ,15816
+Colombia-Boyaca-Topaga,municipality,Colombia,Boyaca,Topaga,NA,BOYACA,TOPAGA,15820
+Colombia-Boyaca-Tota,municipality,Colombia,Boyaca,Tota,NA,BOYACA,TOTA,15822
+Colombia-Boyaca-Tunungua,municipality,Colombia,Boyaca,Tunungua,NA,BOYACA,TUNUNGUA,15832
+Colombia-Boyaca-Turmeque,municipality,Colombia,Boyaca,Turmeque,NA,BOYACA,TURMEQUE,15835
+Colombia-Boyaca-Tuta,municipality,Colombia,Boyaca,Tuta,NA,BOYACA,TUTA,15837
+Colombia-Boyaca-Tutaza,municipality,Colombia,Boyaca,Tutaza,NA,BOYACA,TUTAZA,15839
+Colombia-Boyaca-Umbita,municipality,Colombia,Boyaca,Umbita,NA,BOYACA,UMBITA,15842
+Colombia-Boyaca-Ventaquemada,municipality,Colombia,Boyaca,Ventaquemada,NA,BOYACA,VENTAQUEMADA,15861
+Colombia-Boyaca-Viracacha,municipality,Colombia,Boyaca,Viracacha,NA,BOYACA,VIRACACHA,15879
+Colombia-Boyaca-Zetaquira,municipality,Colombia,Boyaca,Zetaquira,NA,BOYACA,ZETAQUIRA,15897
+Colombia-Caldas-Unknown,municipality,Colombia,Caldas,Unknown,NA,CALDAS,* CALDAS. MUNICIPIO DESCONOCIDO,17000
+Colombia-Caldas-Manizales,municipality,Colombia,Caldas,Manizales,NA,CALDAS,MANIZALES,17001
+Colombia-Caldas-Aguadas,municipality,Colombia,Caldas,Aguadas,NA,CALDAS,AGUADAS,17013
+Colombia-Caldas-Anserma,municipality,Colombia,Caldas,Anserma,NA,CALDAS,ANSERMA,17042
+Colombia-Caldas-Aranzazu,municipality,Colombia,Caldas,Aranzazu,NA,CALDAS,ARANZAZU,17050
+Colombia-Caldas-Belalcazar,municipality,Colombia,Caldas,Belalcazar,NA,CALDAS,BELALCAZAR,17088
+Colombia-Caldas-Chinchina,municipality,Colombia,Caldas,Chinchina,NA,CALDAS,CHINCHINA,17174
+Colombia-Caldas-Filadelfia,municipality,Colombia,Caldas,Filadelfia,NA,CALDAS,FILADELFIA,17272
+Colombia-Caldas-La_Dorada,municipality,Colombia,Caldas,La_Dorada,NA,CALDAS,LA DORADA,17380
+Colombia-Caldas-La_Merced,municipality,Colombia,Caldas,La_Merced,NA,CALDAS,LA MERCED,17388
+Colombia-Caldas-Manzanares,municipality,Colombia,Caldas,Manzanares,NA,CALDAS,MANZANARES,17433
+Colombia-Caldas-Marmato,municipality,Colombia,Caldas,Marmato,NA,CALDAS,MARMATO,17442
+Colombia-Caldas-Marquetalia,municipality,Colombia,Caldas,Marquetalia,NA,CALDAS,MARQUETALIA,17444
+Colombia-Caldas-Marulanda,municipality,Colombia,Caldas,Marulanda,NA,CALDAS,MARULANDA,17446
+Colombia-Caldas-Neira,municipality,Colombia,Caldas,Neira,NA,CALDAS,NEIRA,17486
+Colombia-Caldas-Norcasia,municipality,Colombia,Caldas,Norcasia,NA,CALDAS,NORCASIA,17495
+Colombia-Caldas-Pacora,municipality,Colombia,Caldas,Pacora,NA,CALDAS,PACORA,17513
+Colombia-Caldas-Palestina,municipality,Colombia,Caldas,Palestina,NA,CALDAS,PALESTINA,17524
+Colombia-Caldas-Pensilvania,municipality,Colombia,Caldas,Pensilvania,NA,CALDAS,PENSILVANIA,17541
+Colombia-Caldas-Riosucio,municipality,Colombia,Caldas,Riosucio,NA,CALDAS,RIOSUCIO,17614
+Colombia-Caldas-Risaralda,municipality,Colombia,Caldas,Risaralda,NA,CALDAS,RISARALDA,17616
+Colombia-Caldas-Salamina,municipality,Colombia,Caldas,Salamina,NA,CALDAS,SALAMINA,17653
+Colombia-Caldas-Samana,municipality,Colombia,Caldas,Samana,NA,CALDAS,SAMANA,17662
+Colombia-Caldas-San_Jose,municipality,Colombia,Caldas,San_Jose,NA,CALDAS,SAN JOSE,17665
+Colombia-Caldas-Supia,municipality,Colombia,Caldas,Supia,NA,CALDAS,SUPIA,17777
+Colombia-Caldas-Victoria,municipality,Colombia,Caldas,Victoria,NA,CALDAS,VICTORIA,17867
+Colombia-Caldas-Villamaria,municipality,Colombia,Caldas,Villamaria,NA,CALDAS,VILLAMARIA,17873
+Colombia-Caldas-Viterbo,municipality,Colombia,Caldas,Viterbo,NA,CALDAS,VITERBO,17877
+Colombia-Caqueta-Unknown,municipality,Colombia,Caqueta,Unknown,NA,CAQUETA,* CAQUETA. MUNICIPIO DESCONOCIDO,18000
+Colombia-Caqueta-Florencia,municipality,Colombia,Caqueta,Florencia,NA,CAQUETA,FLORENCIA,18001
+Colombia-Caqueta-Albania,municipality,Colombia,Caqueta,Albania,NA,CAQUETA,ALBANIA,18029
+Colombia-Caqueta-Belen_De_Los_Andaquies,municipality,Colombia,Caqueta,Belen_De_Los_Andaquies,NA,CAQUETA,BELEN DE LOS ANDAQUIES,18094
+Colombia-Caqueta-Cartagena_Del_Chaira,municipality,Colombia,Caqueta,Cartagena_Del_Chaira,NA,CAQUETA,CARTAGENA DEL CHAIRA,18150
+Colombia-Caqueta-Curillo,municipality,Colombia,Caqueta,Curillo,NA,CAQUETA,CURILLO,18205
+Colombia-Caqueta-El_Doncello,municipality,Colombia,Caqueta,El_Doncello,NA,CAQUETA,EL DONCELLO,18247
+Colombia-Caqueta-El_Paujil,municipality,Colombia,Caqueta,El_Paujil,NA,CAQUETA,EL PAUJIL,18256
+Colombia-Caqueta-La_Montanita,municipality,Colombia,Caqueta,La_Montanita,NA,CAQUETA,LA MONTAÑITA,18410
+Colombia-Caqueta-Milan,municipality,Colombia,Caqueta,Milan,NA,CAQUETA,MILAN,18460
+Colombia-Caqueta-Morelia,municipality,Colombia,Caqueta,Morelia,NA,CAQUETA,MORELIA,18479
+Colombia-Caqueta-Puerto_Rico,municipality,Colombia,Caqueta,Puerto_Rico,NA,CAQUETA,PUERTO RICO,18592
+Colombia-Caqueta-San_Jose_Del_Fragua,municipality,Colombia,Caqueta,San_Jose_Del_Fragua,NA,CAQUETA,SAN JOSE DEL FRAGUA,18610
+Colombia-Caqueta-San_Vicente_Del_Caguan,municipality,Colombia,Caqueta,San_Vicente_Del_Caguan,NA,CAQUETA,SAN VICENTE DEL CAGUAN,18753
+Colombia-Caqueta-Solano,municipality,Colombia,Caqueta,Solano,NA,CAQUETA,SOLANO,18756
+Colombia-Caqueta-Solita,municipality,Colombia,Caqueta,Solita,NA,CAQUETA,SOLITA,18785
+Colombia-Caqueta-Valparaiso,municipality,Colombia,Caqueta,Valparaiso,NA,CAQUETA,VALPARAISO,18860
+Colombia-Cauca-Unknown,municipality,Colombia,Cauca,Unknown,NA,CAUCA,* CAUCA. MUNICIPIO DESCONOCIDO,19000
+Colombia-Cauca-Popayan,municipality,Colombia,Cauca,Popayan,NA,CAUCA,POPAYAN,19001
+Colombia-Cauca-Almaguer,municipality,Colombia,Cauca,Almaguer,NA,CAUCA,ALMAGUER,19022
+Colombia-Cauca-Argelia,municipality,Colombia,Cauca,Argelia,NA,CAUCA,ARGELIA,19050
+Colombia-Cauca-Balboa,municipality,Colombia,Cauca,Balboa,NA,CAUCA,BALBOA,19075
+Colombia-Cauca-Bolivar,municipality,Colombia,Cauca,Bolivar,NA,CAUCA,BOLIVAR,19100
+Colombia-Cauca-Buenos_Aires,municipality,Colombia,Cauca,Buenos_Aires,NA,CAUCA,BUENOS AIRES,19110
+Colombia-Cauca-Cajibio,municipality,Colombia,Cauca,Cajibio,NA,CAUCA,CAJIBIO,19130
+Colombia-Cauca-Caldono,municipality,Colombia,Cauca,Caldono,NA,CAUCA,CALDONO,19137
+Colombia-Cauca-Caloto,municipality,Colombia,Cauca,Caloto,NA,CAUCA,CALOTO,19142
+Colombia-Cauca-Corinto,municipality,Colombia,Cauca,Corinto,NA,CAUCA,CORINTO,19212
+Colombia-Cauca-El_Tambo,municipality,Colombia,Cauca,El_Tambo,NA,CAUCA,EL TAMBO,19256
+Colombia-Cauca-Florencia,municipality,Colombia,Cauca,Florencia,NA,CAUCA,FLORENCIA,19290
+Colombia-Cauca-Guachene,municipality,Colombia,Cauca,Guachene,NA,CAUCA,GUACHENE,19300
+Colombia-Cauca-Guapi,municipality,Colombia,Cauca,Guapi,NA,CAUCA,GUAPI,19318
+Colombia-Cauca-Inza,municipality,Colombia,Cauca,Inza,NA,CAUCA,INZA,19355
+Colombia-Cauca-Jambalo,municipality,Colombia,Cauca,Jambalo,NA,CAUCA,JAMBALO,19364
+Colombia-Cauca-La_Sierra,municipality,Colombia,Cauca,La_Sierra,NA,CAUCA,LA SIERRA,19392
+Colombia-Cauca-La_Vega,municipality,Colombia,Cauca,La_Vega,NA,CAUCA,LA VEGA,19397
+Colombia-Cauca-Lopez,municipality,Colombia,Cauca,Lopez,NA,CAUCA,LOPEZ,19418
+Colombia-Cauca-Mercaderes,municipality,Colombia,Cauca,Mercaderes,NA,CAUCA,MERCADERES,19450
+Colombia-Cauca-Miranda,municipality,Colombia,Cauca,Miranda,NA,CAUCA,MIRANDA,19455
+Colombia-Cauca-Morales,municipality,Colombia,Cauca,Morales,NA,CAUCA,MORALES,19473
+Colombia-Cauca-Padilla,municipality,Colombia,Cauca,Padilla,NA,CAUCA,PADILLA,19513
+Colombia-Cauca-Paez,municipality,Colombia,Cauca,Paez,NA,CAUCA,PAEZ,19517
+Colombia-Cauca-Patia,municipality,Colombia,Cauca,Patia,NA,CAUCA,PATIA,19532
+Colombia-Cauca-Piamonte,municipality,Colombia,Cauca,Piamonte,NA,CAUCA,PIAMONTE,19533
+Colombia-Cauca-Piendamo,municipality,Colombia,Cauca,Piendamo,NA,CAUCA,PIENDAMO,19548
+Colombia-Cauca-Puerto_Tejada,municipality,Colombia,Cauca,Puerto_Tejada,NA,CAUCA,PUERTO TEJADA,19573
+Colombia-Cauca-Purace,municipality,Colombia,Cauca,Purace,NA,CAUCA,PURACE,19585
+Colombia-Cauca-Rosas,municipality,Colombia,Cauca,Rosas,NA,CAUCA,ROSAS,19622
+Colombia-Cauca-San_Sebastian,municipality,Colombia,Cauca,San_Sebastian,NA,CAUCA,SAN SEBASTIAN,19693
+Colombia-Cauca-Santander_De_Quilichao,municipality,Colombia,Cauca,Santander_De_Quilichao,NA,CAUCA,SANTANDER DE QUILICHAO,19698
+Colombia-Cauca-Santa_Rosa,municipality,Colombia,Cauca,Santa_Rosa,NA,CAUCA,SANTA ROSA,19701
+Colombia-Cauca-Silvia,municipality,Colombia,Cauca,Silvia,NA,CAUCA,SILVIA,19743
+Colombia-Cauca-Sotara,municipality,Colombia,Cauca,Sotara,NA,CAUCA,SOTARA,19760
+Colombia-Cauca-Suarez,municipality,Colombia,Cauca,Suarez,NA,CAUCA,SUAREZ,19780
+Colombia-Cauca-Sucre,municipality,Colombia,Cauca,Sucre,NA,CAUCA,SUCRE,19785
+Colombia-Cauca-Timbio,municipality,Colombia,Cauca,Timbio,NA,CAUCA,TIMBIO,19807
+Colombia-Cauca-Timbiqui,municipality,Colombia,Cauca,Timbiqui,NA,CAUCA,TIMBIQUI,19809
+Colombia-Cauca-Toribio,municipality,Colombia,Cauca,Toribio,NA,CAUCA,TORIBIO,19821
+Colombia-Cauca-Totoro,municipality,Colombia,Cauca,Totoro,NA,CAUCA,TOTORO,19824
+Colombia-Cauca-Villa_Rica,municipality,Colombia,Cauca,Villa_Rica,NA,CAUCA,VILLA RICA,19845
+Colombia-Cesar-Unknown,municipality,Colombia,Cesar,Unknown,NA,CESAR,* CESAR. MUNICIPIO DESCONOCIDO,20000
+Colombia-Cesar-Valledupar,municipality,Colombia,Cesar,Valledupar,NA,CESAR,VALLEDUPAR,20001
+Colombia-Cesar-Aguachica,municipality,Colombia,Cesar,Aguachica,NA,CESAR,AGUACHICA,20011
+Colombia-Cesar-Agustin_Codazzi,municipality,Colombia,Cesar,Agustin_Codazzi,NA,CESAR,AGUSTIN CODAZZI,20013
+Colombia-Cesar-Astrea,municipality,Colombia,Cesar,Astrea,NA,CESAR,ASTREA,20032
+Colombia-Cesar-Becerril,municipality,Colombia,Cesar,Becerril,NA,CESAR,BECERRIL,20045
+Colombia-Cesar-Bosconia,municipality,Colombia,Cesar,Bosconia,NA,CESAR,BOSCONIA,20060
+Colombia-Cesar-Chimichagua,municipality,Colombia,Cesar,Chimichagua,NA,CESAR,CHIMICHAGUA,20175
+Colombia-Cesar-Chiriguana,municipality,Colombia,Cesar,Chiriguana,NA,CESAR,CHIRIGUANA,20178
+Colombia-Cesar-Curumani,municipality,Colombia,Cesar,Curumani,NA,CESAR,CURUMANI,20228
+Colombia-Cesar-El_Copey,municipality,Colombia,Cesar,El_Copey,NA,CESAR,EL COPEY,20238
+Colombia-Cesar-El_Paso,municipality,Colombia,Cesar,El_Paso,NA,CESAR,EL PASO,20250
+Colombia-Cesar-Gamarra,municipality,Colombia,Cesar,Gamarra,NA,CESAR,GAMARRA,20295
+Colombia-Cesar-Gonzalez,municipality,Colombia,Cesar,Gonzalez,NA,CESAR,GONZALEZ,20310
+Colombia-Cesar-La_Gloria,municipality,Colombia,Cesar,La_Gloria,NA,CESAR,LA GLORIA,20383
+Colombia-Cesar-La_Jagua_De_Ibirico,municipality,Colombia,Cesar,La_Jagua_De_Ibirico,NA,CESAR,LA JAGUA DE IBIRICO,20400
+Colombia-Cesar-Manaure,municipality,Colombia,Cesar,Manaure,NA,CESAR,MANAURE,20443
+Colombia-Cesar-Pailitas,municipality,Colombia,Cesar,Pailitas,NA,CESAR,PAILITAS,20517
+Colombia-Cesar-Pelaya,municipality,Colombia,Cesar,Pelaya,NA,CESAR,PELAYA,20550
+Colombia-Cesar-Pueblo_Bello,municipality,Colombia,Cesar,Pueblo_Bello,NA,CESAR,PUEBLO BELLO,20570
+Colombia-Cesar-Rio_De_Oro,municipality,Colombia,Cesar,Rio_De_Oro,NA,CESAR,RIO DE ORO,20614
+Colombia-Cesar-La_Paz,municipality,Colombia,Cesar,La_Paz,NA,CESAR,LA PAZ,20621
+Colombia-Cesar-San_Alberto,municipality,Colombia,Cesar,San_Alberto,NA,CESAR,SAN ALBERTO,20710
+Colombia-Cesar-San_Diego,municipality,Colombia,Cesar,San_Diego,NA,CESAR,SAN DIEGO,20750
+Colombia-Cesar-San_Martin,municipality,Colombia,Cesar,San_Martin,NA,CESAR,SAN MARTIN,20770
+Colombia-Cesar-Tamalameque,municipality,Colombia,Cesar,Tamalameque,NA,CESAR,TAMALAMEQUE,20787
+Colombia-Cordoba-Unknown,municipality,Colombia,Cordoba,Unknown,NA,CORDOBA,* CORDOBA. MUNICIPIO DESCONOCIDO,23000
+Colombia-Cordoba-Monteria,municipality,Colombia,Cordoba,Monteria,NA,CORDOBA,MONTERIA,23001
+Colombia-Cordoba-Ayapel,municipality,Colombia,Cordoba,Ayapel,NA,CORDOBA,AYAPEL,23068
+Colombia-Cordoba-Buenavista,municipality,Colombia,Cordoba,Buenavista,NA,CORDOBA,BUENAVISTA,23079
+Colombia-Cordoba-Canalete,municipality,Colombia,Cordoba,Canalete,NA,CORDOBA,CANALETE,23090
+Colombia-Cordoba-Cerete,municipality,Colombia,Cordoba,Cerete,NA,CORDOBA,CERETE,23162
+Colombia-Cordoba-Chima,municipality,Colombia,Cordoba,Chima,NA,CORDOBA,CHIMA,23168
+Colombia-Cordoba-Chinu,municipality,Colombia,Cordoba,Chinu,NA,CORDOBA,CHINU,23182
+Colombia-Cordoba-Cienaga_De_Oro,municipality,Colombia,Cordoba,Cienaga_De_Oro,NA,CORDOBA,CIENAGA DE ORO,23189
+Colombia-Cordoba-Cotorra,municipality,Colombia,Cordoba,Cotorra,NA,CORDOBA,COTORRA,23300
+Colombia-Cordoba-La_Apartada,municipality,Colombia,Cordoba,La_Apartada,NA,CORDOBA,LA APARTADA,23350
+Colombia-Cordoba-Lorica,municipality,Colombia,Cordoba,Lorica,NA,CORDOBA,LORICA,23417
+Colombia-Cordoba-Los_Cordobas,municipality,Colombia,Cordoba,Los_Cordobas,NA,CORDOBA,LOS CORDOBAS,23419
+Colombia-Cordoba-Momil,municipality,Colombia,Cordoba,Momil,NA,CORDOBA,MOMIL,23464
+Colombia-Cordoba-Montelibano,municipality,Colombia,Cordoba,Montelibano,NA,CORDOBA,MONTELIBANO,23466
+Colombia-Cordoba-Monitos,municipality,Colombia,Cordoba,Monitos,NA,CORDOBA,MOÑITOS,23500
+Colombia-Cordoba-Planeta_Rica,municipality,Colombia,Cordoba,Planeta_Rica,NA,CORDOBA,PLANETA RICA,23555
+Colombia-Cordoba-Pueblo_Nuevo,municipality,Colombia,Cordoba,Pueblo_Nuevo,NA,CORDOBA,PUEBLO NUEVO,23570
+Colombia-Cordoba-Puerto_Escondido,municipality,Colombia,Cordoba,Puerto_Escondido,NA,CORDOBA,PUERTO ESCONDIDO,23574
+Colombia-Cordoba-Puerto_Libertador,municipality,Colombia,Cordoba,Puerto_Libertador,NA,CORDOBA,PUERTO LIBERTADOR,23580
+Colombia-Cordoba-Purisima,municipality,Colombia,Cordoba,Purisima,NA,CORDOBA,PURISIMA,23586
+Colombia-Cordoba-Sahagun,municipality,Colombia,Cordoba,Sahagun,NA,CORDOBA,SAHAGUN,23660
+Colombia-Cordoba-San_Andres_Sotavento,municipality,Colombia,Cordoba,San_Andres_Sotavento,NA,CORDOBA,SAN ANDRES SOTAVENTO,23670
+Colombia-Cordoba-San_Antero,municipality,Colombia,Cordoba,San_Antero,NA,CORDOBA,SAN ANTERO,23672
+Colombia-Cordoba-San_Bernardo_Del_Viento,municipality,Colombia,Cordoba,San_Bernardo_Del_Viento,NA,CORDOBA,SAN BERNARDO DEL VIENTO,23675
+Colombia-Cordoba-San_Carlos,municipality,Colombia,Cordoba,San_Carlos,NA,CORDOBA,SAN CARLOS,23678
+Colombia-Cordoba-San_Jose_De_Ure,municipality,Colombia,Cordoba,San_Jose_De_Ure,NA,CORDOBA,SAN JOSE DE URE,23682
+Colombia-Cordoba-San_Pelayo,municipality,Colombia,Cordoba,San_Pelayo,NA,CORDOBA,SAN PELAYO,23686
+Colombia-Cordoba-Tierralta,municipality,Colombia,Cordoba,Tierralta,NA,CORDOBA,TIERRALTA,23807
+Colombia-Cordoba-Tuchin,municipality,Colombia,Cordoba,Tuchin,NA,CORDOBA,TUCHIN,23815
+Colombia-Cordoba-Valencia,municipality,Colombia,Cordoba,Valencia,NA,CORDOBA,VALENCIA,23855
+Colombia-Cundinamarca-Unknown,municipality,Colombia,Cundinamarca,Unknown,NA,CUNDINAMARCA,* CUNDINAMARCA. MUNICIPIO DESCONOCIDO,25000
+Colombia-Cundinamarca-Agua_De_Dios,municipality,Colombia,Cundinamarca,Agua_De_Dios,NA,CUNDINAMARCA,AGUA DE DIOS,25001
+Colombia-Cundinamarca-Alban,municipality,Colombia,Cundinamarca,Alban,NA,CUNDINAMARCA,ALBAN,25019
+Colombia-Cundinamarca-Anapoima,municipality,Colombia,Cundinamarca,Anapoima,NA,CUNDINAMARCA,ANAPOIMA,25035
+Colombia-Cundinamarca-Anolaima,municipality,Colombia,Cundinamarca,Anolaima,NA,CUNDINAMARCA,ANOLAIMA,25040
+Colombia-Cundinamarca-Arbelaez,municipality,Colombia,Cundinamarca,Arbelaez,NA,CUNDINAMARCA,ARBELAEZ,25053
+Colombia-Cundinamarca-Beltran,municipality,Colombia,Cundinamarca,Beltran,NA,CUNDINAMARCA,BELTRAN,25086
+Colombia-Cundinamarca-Bituima,municipality,Colombia,Cundinamarca,Bituima,NA,CUNDINAMARCA,BITUIMA,25095
+Colombia-Cundinamarca-Bojaca,municipality,Colombia,Cundinamarca,Bojaca,NA,CUNDINAMARCA,BOJACA,25099
+Colombia-Cundinamarca-Cabrera,municipality,Colombia,Cundinamarca,Cabrera,NA,CUNDINAMARCA,CABRERA,25120
+Colombia-Cundinamarca-Cachipay,municipality,Colombia,Cundinamarca,Cachipay,NA,CUNDINAMARCA,CACHIPAY,25123
+Colombia-Cundinamarca-Cajica,municipality,Colombia,Cundinamarca,Cajica,NA,CUNDINAMARCA,CAJICA,25126
+Colombia-Cundinamarca-Caparrapi,municipality,Colombia,Cundinamarca,Caparrapi,NA,CUNDINAMARCA,CAPARRAPI,25148
+Colombia-Cundinamarca-Caqueza,municipality,Colombia,Cundinamarca,Caqueza,NA,CUNDINAMARCA,CAQUEZA,25151
+Colombia-Cundinamarca-Carmen_De_Carupa,municipality,Colombia,Cundinamarca,Carmen_De_Carupa,NA,CUNDINAMARCA,CARMEN DE CARUPA,25154
+Colombia-Cundinamarca-Chaguani,municipality,Colombia,Cundinamarca,Chaguani,NA,CUNDINAMARCA,CHAGUANI,25168
+Colombia-Cundinamarca-Chia,municipality,Colombia,Cundinamarca,Chia,NA,CUNDINAMARCA,CHIA,25175
+Colombia-Cundinamarca-Chipaque,municipality,Colombia,Cundinamarca,Chipaque,NA,CUNDINAMARCA,CHIPAQUE,25178
+Colombia-Cundinamarca-Choachi,municipality,Colombia,Cundinamarca,Choachi,NA,CUNDINAMARCA,CHOACHI,25181
+Colombia-Cundinamarca-Choconta,municipality,Colombia,Cundinamarca,Choconta,NA,CUNDINAMARCA,CHOCONTA,25183
+Colombia-Cundinamarca-Cogua,municipality,Colombia,Cundinamarca,Cogua,NA,CUNDINAMARCA,COGUA,25200
+Colombia-Cundinamarca-Cota,municipality,Colombia,Cundinamarca,Cota,NA,CUNDINAMARCA,COTA,25214
+Colombia-Cundinamarca-Cucunuba,municipality,Colombia,Cundinamarca,Cucunuba,NA,CUNDINAMARCA,CUCUNUBA,25224
+Colombia-Cundinamarca-El_Colegio,municipality,Colombia,Cundinamarca,El_Colegio,NA,CUNDINAMARCA,EL COLEGIO,25245
+Colombia-Cundinamarca-El_Penon,municipality,Colombia,Cundinamarca,El_Penon,NA,CUNDINAMARCA,EL PEÑON,25258
+Colombia-Cundinamarca-El_Rosal,municipality,Colombia,Cundinamarca,El_Rosal,NA,CUNDINAMARCA,EL ROSAL,25260
+Colombia-Cundinamarca-Facatativa,municipality,Colombia,Cundinamarca,Facatativa,NA,CUNDINAMARCA,FACATATIVA,25269
+Colombia-Cundinamarca-Fomeque,municipality,Colombia,Cundinamarca,Fomeque,NA,CUNDINAMARCA,FOMEQUE,25279
+Colombia-Cundinamarca-Fosca,municipality,Colombia,Cundinamarca,Fosca,NA,CUNDINAMARCA,FOSCA,25281
+Colombia-Cundinamarca-Funza,municipality,Colombia,Cundinamarca,Funza,NA,CUNDINAMARCA,FUNZA,25286
+Colombia-Cundinamarca-Fuquene,municipality,Colombia,Cundinamarca,Fuquene,NA,CUNDINAMARCA,FUQUENE,25288
+Colombia-Cundinamarca-Fusagasuga,municipality,Colombia,Cundinamarca,Fusagasuga,NA,CUNDINAMARCA,FUSAGASUGA,25290
+Colombia-Cundinamarca-Gachala,municipality,Colombia,Cundinamarca,Gachala,NA,CUNDINAMARCA,GACHALA,25293
+Colombia-Cundinamarca-Gachancipa,municipality,Colombia,Cundinamarca,Gachancipa,NA,CUNDINAMARCA,GACHANCIPA,25295
+Colombia-Cundinamarca-Gacheta,municipality,Colombia,Cundinamarca,Gacheta,NA,CUNDINAMARCA,GACHETA,25297
+Colombia-Cundinamarca-Gama,municipality,Colombia,Cundinamarca,Gama,NA,CUNDINAMARCA,GAMA,25299
+Colombia-Cundinamarca-Girardot,municipality,Colombia,Cundinamarca,Girardot,NA,CUNDINAMARCA,GIRARDOT,25307
+Colombia-Cundinamarca-Granada,municipality,Colombia,Cundinamarca,Granada,NA,CUNDINAMARCA,GRANADA,25312
+Colombia-Cundinamarca-Guacheta,municipality,Colombia,Cundinamarca,Guacheta,NA,CUNDINAMARCA,GUACHETA,25317
+Colombia-Cundinamarca-Guaduas,municipality,Colombia,Cundinamarca,Guaduas,NA,CUNDINAMARCA,GUADUAS,25320
+Colombia-Cundinamarca-Guasca,municipality,Colombia,Cundinamarca,Guasca,NA,CUNDINAMARCA,GUASCA,25322
+Colombia-Cundinamarca-Guataqui,municipality,Colombia,Cundinamarca,Guataqui,NA,CUNDINAMARCA,GUATAQUI,25324
+Colombia-Cundinamarca-Guatavita,municipality,Colombia,Cundinamarca,Guatavita,NA,CUNDINAMARCA,GUATAVITA,25326
+Colombia-Cundinamarca-Topaipi,municipality,Colombia,Cundinamarca,Topaipi,NA,CUNDINAMARCA,TOPAIPI,25823
+Colombia-Cundinamarca-Guayabal_De_Siquima,municipality,Colombia,Cundinamarca,Guayabal_De_Siquima,NA,CUNDINAMARCA,GUAYABAL DE SIQUIMA,25328
+Colombia-Cundinamarca-Guayabetal,municipality,Colombia,Cundinamarca,Guayabetal,NA,CUNDINAMARCA,GUAYABETAL,25335
+Colombia-Cundinamarca-Gutierrez,municipality,Colombia,Cundinamarca,Gutierrez,NA,CUNDINAMARCA,GUTIERREZ,25339
+Colombia-Cundinamarca-Jerusalen,municipality,Colombia,Cundinamarca,Jerusalen,NA,CUNDINAMARCA,JERUSALEN,25368
+Colombia-Cundinamarca-Junin,municipality,Colombia,Cundinamarca,Junin,NA,CUNDINAMARCA,JUNIN,25372
+Colombia-Cundinamarca-La_Calera,municipality,Colombia,Cundinamarca,La_Calera,NA,CUNDINAMARCA,LA CALERA,25377
+Colombia-Cundinamarca-La_Mesa,municipality,Colombia,Cundinamarca,La_Mesa,NA,CUNDINAMARCA,LA MESA,25386
+Colombia-Cundinamarca-La_Palma,municipality,Colombia,Cundinamarca,La_Palma,NA,CUNDINAMARCA,LA PALMA,25394
+Colombia-Cundinamarca-La_Pena,municipality,Colombia,Cundinamarca,La_Pena,NA,CUNDINAMARCA,LA PEÑA,25398
+Colombia-Cundinamarca-La_Vega,municipality,Colombia,Cundinamarca,La_Vega,NA,CUNDINAMARCA,LA VEGA,25402
+Colombia-Cundinamarca-Lenguazaque,municipality,Colombia,Cundinamarca,Lenguazaque,NA,CUNDINAMARCA,LENGUAZAQUE,25407
+Colombia-Cundinamarca-Macheta,municipality,Colombia,Cundinamarca,Macheta,NA,CUNDINAMARCA,MACHETA,25426
+Colombia-Cundinamarca-Madrid,municipality,Colombia,Cundinamarca,Madrid,NA,CUNDINAMARCA,MADRID,25430
+Colombia-Cundinamarca-Manta,municipality,Colombia,Cundinamarca,Manta,NA,CUNDINAMARCA,MANTA,25436
+Colombia-Cundinamarca-Medina,municipality,Colombia,Cundinamarca,Medina,NA,CUNDINAMARCA,MEDINA,25438
+Colombia-Cundinamarca-Mosquera,municipality,Colombia,Cundinamarca,Mosquera,NA,CUNDINAMARCA,MOSQUERA,25473
+Colombia-Cundinamarca-Narino,municipality,Colombia,Cundinamarca,Narino,NA,CUNDINAMARCA,NARIÑO,25483
+Colombia-Cundinamarca-Nemocon,municipality,Colombia,Cundinamarca,Nemocon,NA,CUNDINAMARCA,NEMOCON,25486
+Colombia-Cundinamarca-Nilo,municipality,Colombia,Cundinamarca,Nilo,NA,CUNDINAMARCA,NILO,25488
+Colombia-Cundinamarca-Nimaima,municipality,Colombia,Cundinamarca,Nimaima,NA,CUNDINAMARCA,NIMAIMA,25489
+Colombia-Cundinamarca-Nocaima,municipality,Colombia,Cundinamarca,Nocaima,NA,CUNDINAMARCA,NOCAIMA,25491
+Colombia-Cundinamarca-Venecia,municipality,Colombia,Cundinamarca,Venecia,NA,CUNDINAMARCA,VENECIA,25506
+Colombia-Cundinamarca-Pacho,municipality,Colombia,Cundinamarca,Pacho,NA,CUNDINAMARCA,PACHO,25513
+Colombia-Cundinamarca-Paime,municipality,Colombia,Cundinamarca,Paime,NA,CUNDINAMARCA,PAIME,25518
+Colombia-Cundinamarca-Pandi,municipality,Colombia,Cundinamarca,Pandi,NA,CUNDINAMARCA,PANDI,25524
+Colombia-Cundinamarca-Paratebueno,municipality,Colombia,Cundinamarca,Paratebueno,NA,CUNDINAMARCA,PARATEBUENO,25530
+Colombia-Cundinamarca-Pasca,municipality,Colombia,Cundinamarca,Pasca,NA,CUNDINAMARCA,PASCA,25535
+Colombia-Cundinamarca-Puerto_Salgar,municipality,Colombia,Cundinamarca,Puerto_Salgar,NA,CUNDINAMARCA,PUERTO SALGAR,25572
+Colombia-Cundinamarca-Puli,municipality,Colombia,Cundinamarca,Puli,NA,CUNDINAMARCA,PULI,25580
+Colombia-Cundinamarca-Quebradanegra,municipality,Colombia,Cundinamarca,Quebradanegra,NA,CUNDINAMARCA,QUEBRADANEGRA,25592
+Colombia-Cundinamarca-Quetame,municipality,Colombia,Cundinamarca,Quetame,NA,CUNDINAMARCA,QUETAME,25594
+Colombia-Cundinamarca-Quipile,municipality,Colombia,Cundinamarca,Quipile,NA,CUNDINAMARCA,QUIPILE,25596
+Colombia-Cundinamarca-Apulo,municipality,Colombia,Cundinamarca,Apulo,NA,CUNDINAMARCA,APULO,25599
+Colombia-Cundinamarca-Ricaurte,municipality,Colombia,Cundinamarca,Ricaurte,NA,CUNDINAMARCA,RICAURTE,25612
+Colombia-Cundinamarca-San_Antonio_Del_Tequendama,municipality,Colombia,Cundinamarca,San_Antonio_Del_Tequendama,NA,CUNDINAMARCA,SAN ANTONIO DEL TEQUENDAMA,25645
+Colombia-Cundinamarca-San_Bernardo,municipality,Colombia,Cundinamarca,San_Bernardo,NA,CUNDINAMARCA,SAN BERNARDO,25649
+Colombia-Cundinamarca-San_Cayetano,municipality,Colombia,Cundinamarca,San_Cayetano,NA,CUNDINAMARCA,SAN CAYETANO,25653
+Colombia-Cundinamarca-San_Francisco,municipality,Colombia,Cundinamarca,San_Francisco,NA,CUNDINAMARCA,SAN FRANCISCO,25658
+Colombia-Cundinamarca-San_Juan_De_Rio_Seco,municipality,Colombia,Cundinamarca,San_Juan_De_Rio_Seco,NA,CUNDINAMARCA,SAN JUAN DE RIO SECO,25662
+Colombia-Cundinamarca-Sasaima,municipality,Colombia,Cundinamarca,Sasaima,NA,CUNDINAMARCA,SASAIMA,25718
+Colombia-Cundinamarca-Sesquile,municipality,Colombia,Cundinamarca,Sesquile,NA,CUNDINAMARCA,SESQUILE,25736
+Colombia-Cundinamarca-Sibate,municipality,Colombia,Cundinamarca,Sibate,NA,CUNDINAMARCA,SIBATE,25740
+Colombia-Cundinamarca-Silvania,municipality,Colombia,Cundinamarca,Silvania,NA,CUNDINAMARCA,SILVANIA,25743
+Colombia-Cundinamarca-Simijaca,municipality,Colombia,Cundinamarca,Simijaca,NA,CUNDINAMARCA,SIMIJACA,25745
+Colombia-Cundinamarca-Soacha,municipality,Colombia,Cundinamarca,Soacha,NA,CUNDINAMARCA,SOACHA,25754
+Colombia-Cundinamarca-Sopo,municipality,Colombia,Cundinamarca,Sopo,NA,CUNDINAMARCA,SOPO,25758
+Colombia-Cundinamarca-Subachoque,municipality,Colombia,Cundinamarca,Subachoque,NA,CUNDINAMARCA,SUBACHOQUE,25769
+Colombia-Cundinamarca-Suesca,municipality,Colombia,Cundinamarca,Suesca,NA,CUNDINAMARCA,SUESCA,25772
+Colombia-Cundinamarca-Supata,municipality,Colombia,Cundinamarca,Supata,NA,CUNDINAMARCA,SUPATA,25777
+Colombia-Cundinamarca-Susa,municipality,Colombia,Cundinamarca,Susa,NA,CUNDINAMARCA,SUSA,25779
+Colombia-Cundinamarca-Sutatausa,municipality,Colombia,Cundinamarca,Sutatausa,NA,CUNDINAMARCA,SUTATAUSA,25781
+Colombia-Cundinamarca-Tabio,municipality,Colombia,Cundinamarca,Tabio,NA,CUNDINAMARCA,TABIO,25785
+Colombia-Cundinamarca-Tausa,municipality,Colombia,Cundinamarca,Tausa,NA,CUNDINAMARCA,TAUSA,25793
+Colombia-Cundinamarca-Tena,municipality,Colombia,Cundinamarca,Tena,NA,CUNDINAMARCA,TENA,25797
+Colombia-Cundinamarca-Tenjo,municipality,Colombia,Cundinamarca,Tenjo,NA,CUNDINAMARCA,TENJO,25799
+Colombia-Cundinamarca-Tibacuy,municipality,Colombia,Cundinamarca,Tibacuy,NA,CUNDINAMARCA,TIBACUY,25805
+Colombia-Cundinamarca-Tibirita,municipality,Colombia,Cundinamarca,Tibirita,NA,CUNDINAMARCA,TIBIRITA,25807
+Colombia-Cundinamarca-Tocaima,municipality,Colombia,Cundinamarca,Tocaima,NA,CUNDINAMARCA,TOCAIMA,25815
+Colombia-Cundinamarca-Tocancipa,municipality,Colombia,Cundinamarca,Tocancipa,NA,CUNDINAMARCA,TOCANCIPA,25817
+Colombia-Cundinamarca-Ubala,municipality,Colombia,Cundinamarca,Ubala,NA,CUNDINAMARCA,UBALA,25839
+Colombia-Cundinamarca-Ubaque,municipality,Colombia,Cundinamarca,Ubaque,NA,CUNDINAMARCA,UBAQUE,25841
+Colombia-Cundinamarca-Villa_De_San_Diego_De_Ubate,municipality,Colombia,Cundinamarca,Villa_De_San_Diego_De_Ubate,NA,CUNDINAMARCA,VILLA DE SAN DIEGO DE UBATE,25843
+Colombia-Cundinamarca-Une,municipality,Colombia,Cundinamarca,Une,NA,CUNDINAMARCA,UNE,25845
+Colombia-Cundinamarca-Utica,municipality,Colombia,Cundinamarca,Utica,NA,CUNDINAMARCA,UTICA,25851
+Colombia-Cundinamarca-Vergara,municipality,Colombia,Cundinamarca,Vergara,NA,CUNDINAMARCA,VERGARA,25862
+Colombia-Cundinamarca-Viani,municipality,Colombia,Cundinamarca,Viani,NA,CUNDINAMARCA,VIANI,25867
+Colombia-Cundinamarca-Villagomez,municipality,Colombia,Cundinamarca,Villagomez,NA,CUNDINAMARCA,VILLAGOMEZ,25871
+Colombia-Cundinamarca-Villapinzon,municipality,Colombia,Cundinamarca,Villapinzon,NA,CUNDINAMARCA,VILLAPINZON,25873
+Colombia-Cundinamarca-Villeta,municipality,Colombia,Cundinamarca,Villeta,NA,CUNDINAMARCA,VILLETA,25875
+Colombia-Cundinamarca-Viota,municipality,Colombia,Cundinamarca,Viota,NA,CUNDINAMARCA,VIOTA,25878
+Colombia-Cundinamarca-Yacopi,municipality,Colombia,Cundinamarca,Yacopi,NA,CUNDINAMARCA,YACOPI,25885
+Colombia-Cundinamarca-Zipacon,municipality,Colombia,Cundinamarca,Zipacon,NA,CUNDINAMARCA,ZIPACON,25898
+Colombia-Cundinamarca-Zipaquira,municipality,Colombia,Cundinamarca,Zipaquira,NA,CUNDINAMARCA,ZIPAQUIRA,25899
+Colombia-Choco-Unknown,municipality,Colombia,Choco,Unknown,NA,CHOCO,* CHOCO. MUNICIPIO DESCONOCIDO,27000
+Colombia-Choco-Quibdo,municipality,Colombia,Choco,Quibdo,NA,CHOCO,QUIBDO,27001
+Colombia-Choco-Acandi,municipality,Colombia,Choco,Acandi,NA,CHOCO,ACANDI,27006
+Colombia-Choco-Alto_Baudo,municipality,Colombia,Choco,Alto_Baudo,NA,CHOCO,ALTO BAUDO,27025
+Colombia-Choco-Atrato,municipality,Colombia,Choco,Atrato,NA,CHOCO,ATRATO,27050
+Colombia-Choco-Bagado,municipality,Colombia,Choco,Bagado,NA,CHOCO,BAGADO,27073
+Colombia-Choco-Bahia_Solano,municipality,Colombia,Choco,Bahia_Solano,NA,CHOCO,BAHIA SOLANO,27075
+Colombia-Choco-Bajo_Baudo,municipality,Colombia,Choco,Bajo_Baudo,NA,CHOCO,BAJO BAUDO,27077
+Colombia-Choco-Belen_De_Bajira,municipality,Colombia,Choco,Belen_De_Bajira,NA,CHOCO,BELEN DE BAJIRA,27086
+Colombia-Choco-Bojaya,municipality,Colombia,Choco,Bojaya,NA,CHOCO,BOJAYA,27099
+Colombia-Choco-El_Canton_Del_San_Pablo,municipality,Colombia,Choco,El_Canton_Del_San_Pablo,NA,CHOCO,EL CANTON DEL SAN PABLO,27135
+Colombia-Choco-Carmen_Del_Darien,municipality,Colombia,Choco,Carmen_Del_Darien,NA,CHOCO,CARMEN DEL DARIEN,27150
+Colombia-Choco-Certegui,municipality,Colombia,Choco,Certegui,NA,CHOCO,CERTEGUI,27160
+Colombia-Choco-Condoto,municipality,Colombia,Choco,Condoto,NA,CHOCO,CONDOTO,27205
+Colombia-Choco-El_Carmen_De_Atrato,municipality,Colombia,Choco,El_Carmen_De_Atrato,NA,CHOCO,EL CARMEN DE ATRATO,27245
+Colombia-Choco-El_Litoral_Del_San_Juan,municipality,Colombia,Choco,El_Litoral_Del_San_Juan,NA,CHOCO,EL LITORAL DEL SAN JUAN,27250
+Colombia-Choco-Istmina,municipality,Colombia,Choco,Istmina,NA,CHOCO,ISTMINA,27361
+Colombia-Choco-Jurado,municipality,Colombia,Choco,Jurado,NA,CHOCO,JURADO,27372
+Colombia-Choco-Lloro,municipality,Colombia,Choco,Lloro,NA,CHOCO,LLORO,27413
+Colombia-Choco-Medio_Atrato,municipality,Colombia,Choco,Medio_Atrato,NA,CHOCO,MEDIO ATRATO,27425
+Colombia-Choco-Medio_Baudo,municipality,Colombia,Choco,Medio_Baudo,NA,CHOCO,MEDIO BAUDO,27430
+Colombia-Choco-Medio_San_Juan,municipality,Colombia,Choco,Medio_San_Juan,NA,CHOCO,MEDIO SAN JUAN,27450
+Colombia-Choco-Novita,municipality,Colombia,Choco,Novita,NA,CHOCO,NOVITA,27491
+Colombia-Choco-Nuqui,municipality,Colombia,Choco,Nuqui,NA,CHOCO,NUQUI,27495
+Colombia-Choco-Rio_Iro,municipality,Colombia,Choco,Rio_Iro,NA,CHOCO,RIO IRO,27580
+Colombia-Choco-Rio_Quito,municipality,Colombia,Choco,Rio_Quito,NA,CHOCO,RIO QUITO,27600
+Colombia-Choco-Riosucio,municipality,Colombia,Choco,Riosucio,NA,CHOCO,RIOSUCIO,27615
+Colombia-Choco-San_Jose_Del_Palmar,municipality,Colombia,Choco,San_Jose_Del_Palmar,NA,CHOCO,SAN JOSE DEL PALMAR,27660
+Colombia-Choco-Sipi,municipality,Colombia,Choco,Sipi,NA,CHOCO,SIPI,27745
+Colombia-Choco-Tado,municipality,Colombia,Choco,Tado,NA,CHOCO,TADO,27787
+Colombia-Choco-Unguia,municipality,Colombia,Choco,Unguia,NA,CHOCO,UNGUIA,27800
+Colombia-Choco-Union_Panamericana,municipality,Colombia,Choco,Union_Panamericana,NA,CHOCO,UNION PANAMERICANA,27810
+Colombia-Huila-Unknown,municipality,Colombia,Huila,Unknown,NA,HUILA,* HUILA. MUNICIPIO DESCONOCIDO,41000
+Colombia-Huila-Neiva,municipality,Colombia,Huila,Neiva,NA,HUILA,NEIVA,41001
+Colombia-Huila-Acevedo,municipality,Colombia,Huila,Acevedo,NA,HUILA,ACEVEDO,41006
+Colombia-Huila-Agrado,municipality,Colombia,Huila,Agrado,NA,HUILA,AGRADO,41013
+Colombia-Huila-Aipe,municipality,Colombia,Huila,Aipe,NA,HUILA,AIPE,41016
+Colombia-Huila-Algeciras,municipality,Colombia,Huila,Algeciras,NA,HUILA,ALGECIRAS,41020
+Colombia-Huila-Altamira,municipality,Colombia,Huila,Altamira,NA,HUILA,ALTAMIRA,41026
+Colombia-Huila-Baraya,municipality,Colombia,Huila,Baraya,NA,HUILA,BARAYA,41078
+Colombia-Huila-Campoalegre,municipality,Colombia,Huila,Campoalegre,NA,HUILA,CAMPOALEGRE,41132
+Colombia-Huila-Colombia,municipality,Colombia,Huila,Colombia,NA,HUILA,COLOMBIA,41206
+Colombia-Huila-Elias,municipality,Colombia,Huila,Elias,NA,HUILA,ELIAS,41244
+Colombia-Huila-Garzon,municipality,Colombia,Huila,Garzon,NA,HUILA,GARZON,41298
+Colombia-Huila-Gigante,municipality,Colombia,Huila,Gigante,NA,HUILA,GIGANTE,41306
+Colombia-Huila-Guadalupe,municipality,Colombia,Huila,Guadalupe,NA,HUILA,GUADALUPE,41319
+Colombia-Huila-Hobo,municipality,Colombia,Huila,Hobo,NA,HUILA,HOBO,41349
+Colombia-Huila-Iquira,municipality,Colombia,Huila,Iquira,NA,HUILA,IQUIRA,41357
+Colombia-Huila-Isnos,municipality,Colombia,Huila,Isnos,NA,HUILA,ISNOS,41359
+Colombia-Huila-La_Argentina,municipality,Colombia,Huila,La_Argentina,NA,HUILA,LA ARGENTINA,41378
+Colombia-Huila-La_Plata,municipality,Colombia,Huila,La_Plata,NA,HUILA,LA PLATA,41396
+Colombia-Huila-Nataga,municipality,Colombia,Huila,Nataga,NA,HUILA,NATAGA,41483
+Colombia-Huila-Oporapa,municipality,Colombia,Huila,Oporapa,NA,HUILA,OPORAPA,41503
+Colombia-Huila-Paicol,municipality,Colombia,Huila,Paicol,NA,HUILA,PAICOL,41518
+Colombia-Huila-Palermo,municipality,Colombia,Huila,Palermo,NA,HUILA,PALERMO,41524
+Colombia-Huila-Palestina,municipality,Colombia,Huila,Palestina,NA,HUILA,PALESTINA,41530
+Colombia-Huila-Pital,municipality,Colombia,Huila,Pital,NA,HUILA,PITAL,41548
+Colombia-Huila-Pitalito,municipality,Colombia,Huila,Pitalito,NA,HUILA,PITALITO,41551
+Colombia-Huila-Rivera,municipality,Colombia,Huila,Rivera,NA,HUILA,RIVERA,41615
+Colombia-Huila-Saladoblanco,municipality,Colombia,Huila,Saladoblanco,NA,HUILA,SALADOBLANCO,41660
+Colombia-Huila-San_Agustin,municipality,Colombia,Huila,San_Agustin,NA,HUILA,SAN AGUSTIN,41668
+Colombia-Huila-Santa_Maria,municipality,Colombia,Huila,Santa_Maria,NA,HUILA,SANTA MARIA,41676
+Colombia-Huila-Suaza,municipality,Colombia,Huila,Suaza,NA,HUILA,SUAZA,41770
+Colombia-Huila-Tarqui,municipality,Colombia,Huila,Tarqui,NA,HUILA,TARQUI,41791
+Colombia-Huila-Tesalia,municipality,Colombia,Huila,Tesalia,NA,HUILA,TESALIA,41797
+Colombia-Huila-Tello,municipality,Colombia,Huila,Tello,NA,HUILA,TELLO,41799
+Colombia-Huila-Teruel,municipality,Colombia,Huila,Teruel,NA,HUILA,TERUEL,41801
+Colombia-Huila-Timana,municipality,Colombia,Huila,Timana,NA,HUILA,TIMANA,41807
+Colombia-Huila-Villavieja,municipality,Colombia,Huila,Villavieja,NA,HUILA,VILLAVIEJA,41872
+Colombia-Huila-Yaguara,municipality,Colombia,Huila,Yaguara,NA,HUILA,YAGUARA,41885
+Colombia-Guajira-Unknown,municipality,Colombia,Guajira,Unknown,NA,GUAJIRA,* LA GUAJIRA. MUNICIPIO DESCONOCIDO,44000
+Colombia-Guajira-Riohacha,municipality,Colombia,Guajira,Riohacha,NA,GUAJIRA,RIOHACHA,44001
+Colombia-Guajira-Albania,municipality,Colombia,Guajira,Albania,NA,GUAJIRA,ALBANIA,44035
+Colombia-Guajira-Barrancas,municipality,Colombia,Guajira,Barrancas,NA,GUAJIRA,BARRANCAS,44078
+Colombia-Guajira-Dibulla,municipality,Colombia,Guajira,Dibulla,NA,GUAJIRA,DIBULLA,44090
+Colombia-Guajira-Distraccion,municipality,Colombia,Guajira,Distraccion,NA,GUAJIRA,DISTRACCION,44098
+Colombia-Guajira-El_Molino,municipality,Colombia,Guajira,El_Molino,NA,GUAJIRA,EL MOLINO,44110
+Colombia-Guajira-Fonseca,municipality,Colombia,Guajira,Fonseca,NA,GUAJIRA,FONSECA,44279
+Colombia-Guajira-Hatonuevo,municipality,Colombia,Guajira,Hatonuevo,NA,GUAJIRA,HATONUEVO,44378
+Colombia-Guajira-La_Jagua_Del_Pilar,municipality,Colombia,Guajira,La_Jagua_Del_Pilar,NA,GUAJIRA,LA JAGUA DEL PILAR,44420
+Colombia-Guajira-Maicao,municipality,Colombia,Guajira,Maicao,NA,GUAJIRA,MAICAO,44430
+Colombia-Guajira-Manaure,municipality,Colombia,Guajira,Manaure,NA,GUAJIRA,MANAURE,44560
+Colombia-Guajira-San_Juan_Del_Cesar,municipality,Colombia,Guajira,San_Juan_Del_Cesar,NA,GUAJIRA,SAN JUAN DEL CESAR,44650
+Colombia-Guajira-Uribia,municipality,Colombia,Guajira,Uribia,NA,GUAJIRA,URIBIA,44847
+Colombia-Guajira-Urumita,municipality,Colombia,Guajira,Urumita,NA,GUAJIRA,URUMITA,44855
+Colombia-Guajira-Villanueva,municipality,Colombia,Guajira,Villanueva,NA,GUAJIRA,VILLANUEVA,44874
+Colombia-Sta_Marta_D.E.-Santa_Marta,municipality,Colombia,Sta_Marta_D.E.,Santa_Marta,NA,STA MARTA D.E.,SANTA MARTA,48001
+Colombia-Magdalena-Sitio_Nuevo,municipality,Colombia,Magdalena,Sitio_Nuevo,NA,MAGDALENA,* MAGDALENA. MUNICIPIO DESCONOCIDO,47000
+Colombia-Magdalena-Unknown,municipality,Colombia,Magdalena,Unknown,NA,MAGDALENA,* MAGDALENA. MUNICIPIO DESCONOCIDO,47000
+Colombia-Magdalena-Algarrobo,municipality,Colombia,Magdalena,Algarrobo,NA,MAGDALENA,ALGARROBO,47030
+Colombia-Magdalena-Aracataca,municipality,Colombia,Magdalena,Aracataca,NA,MAGDALENA,ARACATACA,47053
+Colombia-Magdalena-Ariguani,municipality,Colombia,Magdalena,Ariguani,NA,MAGDALENA,ARIGUANI,47058
+Colombia-Magdalena-Cerro_San_Antonio,municipality,Colombia,Magdalena,Cerro_San_Antonio,NA,MAGDALENA,CERRO SAN ANTONIO,47161
+Colombia-Magdalena-Chibolo,municipality,Colombia,Magdalena,Chibolo,NA,MAGDALENA,CHIBOLO,47170
+Colombia-Magdalena-Cienaga,municipality,Colombia,Magdalena,Cienaga,NA,MAGDALENA,CIENAGA,47189
+Colombia-Magdalena-Concordia,municipality,Colombia,Magdalena,Concordia,NA,MAGDALENA,CONCORDIA,47205
+Colombia-Magdalena-El_Banco,municipality,Colombia,Magdalena,El_Banco,NA,MAGDALENA,EL BANCO,47245
+Colombia-Magdalena-El_Pinon,municipality,Colombia,Magdalena,El_Pinon,NA,MAGDALENA,EL PIÑON,47258
+Colombia-Magdalena-El_Reten,municipality,Colombia,Magdalena,El_Reten,NA,MAGDALENA,EL RETEN,47268
+Colombia-Magdalena-Fundacion,municipality,Colombia,Magdalena,Fundacion,NA,MAGDALENA,FUNDACION,47288
+Colombia-Magdalena-Guamal,municipality,Colombia,Magdalena,Guamal,NA,MAGDALENA,GUAMAL,47318
+Colombia-Magdalena-Nueva_Granada,municipality,Colombia,Magdalena,Nueva_Granada,NA,MAGDALENA,NUEVA GRANADA,47460
+Colombia-Magdalena-Pedraza,municipality,Colombia,Magdalena,Pedraza,NA,MAGDALENA,PEDRAZA,47541
+Colombia-Magdalena-Pijino_Del_Carmen,municipality,Colombia,Magdalena,Pijino_Del_Carmen,NA,MAGDALENA,PIJIÑO DEL CARMEN,47545
+Colombia-Magdalena-Pivijay,municipality,Colombia,Magdalena,Pivijay,NA,MAGDALENA,PIVIJAY,47551
+Colombia-Magdalena-Plato,municipality,Colombia,Magdalena,Plato,NA,MAGDALENA,PLATO,47555
+Colombia-Magdalena-Puebloviejo,municipality,Colombia,Magdalena,Puebloviejo,NA,MAGDALENA,PUEBLOVIEJO,47570
+Colombia-Magdalena-Remolino,municipality,Colombia,Magdalena,Remolino,NA,MAGDALENA,REMOLINO,47605
+Colombia-Magdalena-Sabanas_De_San_Angel,municipality,Colombia,Magdalena,Sabanas_De_San_Angel,NA,MAGDALENA,SABANAS DE SAN ANGEL,47660
+Colombia-Magdalena-Salamina,municipality,Colombia,Magdalena,Salamina,NA,MAGDALENA,SALAMINA,47675
+Colombia-Magdalena-San_Sebastian_De_Buenavista,municipality,Colombia,Magdalena,San_Sebastian_De_Buenavista,NA,MAGDALENA,SAN SEBASTIAN DE BUENAVISTA,47692
+Colombia-Magdalena-San_Zenon,municipality,Colombia,Magdalena,San_Zenon,NA,MAGDALENA,SAN ZENON,47703
+Colombia-Magdalena-Santa_Ana,municipality,Colombia,Magdalena,Santa_Ana,NA,MAGDALENA,SANTA ANA,47707
+Colombia-Magdalena-Santa_Barbara_De_Pinto,municipality,Colombia,Magdalena,Santa_Barbara_De_Pinto,NA,MAGDALENA,SANTA BARBARA DE PINTO,47720
+Colombia-Magdalena-Sitionuevo,municipality,Colombia,Magdalena,Sitionuevo,NA,MAGDALENA,SITIONUEVO,47745
+Colombia-Magdalena-Tenerife,municipality,Colombia,Magdalena,Tenerife,NA,MAGDALENA,TENERIFE,47798
+Colombia-Magdalena-Zapayan,municipality,Colombia,Magdalena,Zapayan,NA,MAGDALENA,ZAPAYAN,47960
+Colombia-Magdalena-Zona_Bananera,municipality,Colombia,Magdalena,Zona_Bananera,NA,MAGDALENA,ZONA BANANERA,47980
+Colombia-Meta-Unknown,municipality,Colombia,Meta,Unknown,NA,META,* META. MUNICIPIO DESCONOCIDO,50000
+Colombia-Meta-Villavicencio,municipality,Colombia,Meta,Villavicencio,NA,META,VILLAVICENCIO,50001
+Colombia-Meta-Acacias,municipality,Colombia,Meta,Acacias,NA,META,ACACIAS,50006
+Colombia-Meta-Barranca_De_Upia,municipality,Colombia,Meta,Barranca_De_Upia,NA,META,BARRANCA DE UPIA,50110
+Colombia-Meta-Cabuyaro,municipality,Colombia,Meta,Cabuyaro,NA,META,CABUYARO,50124
+Colombia-Meta-Castilla_La_Nueva,municipality,Colombia,Meta,Castilla_La_Nueva,NA,META,CASTILLA LA NUEVA,50150
+Colombia-Meta-Cubarral,municipality,Colombia,Meta,Cubarral,NA,META,CUBARRAL,50223
+Colombia-Meta-Cumaral,municipality,Colombia,Meta,Cumaral,NA,META,CUMARAL,50226
+Colombia-Meta-El_Calvario,municipality,Colombia,Meta,El_Calvario,NA,META,EL CALVARIO,50245
+Colombia-Meta-El_Castillo,municipality,Colombia,Meta,El_Castillo,NA,META,EL CASTILLO,50251
+Colombia-Meta-El_Dorado,municipality,Colombia,Meta,El_Dorado,NA,META,EL DORADO,50270
+Colombia-Meta-Fuente_De_Oro,municipality,Colombia,Meta,Fuente_De_Oro,NA,META,FUENTE DE ORO,50287
+Colombia-Meta-Granada,municipality,Colombia,Meta,Granada,NA,META,GRANADA,50313
+Colombia-Meta-Guamal,municipality,Colombia,Meta,Guamal,NA,META,GUAMAL,50318
+Colombia-Meta-Mapiripan,municipality,Colombia,Meta,Mapiripan,NA,META,MAPIRIPAN,50325
+Colombia-Meta-Mesetas,municipality,Colombia,Meta,Mesetas,NA,META,MESETAS,50330
+Colombia-Meta-La_Macarena,municipality,Colombia,Meta,La_Macarena,NA,META,LA MACARENA,50350
+Colombia-Meta-Uribe,municipality,Colombia,Meta,Uribe,NA,META,URIBE,50370
+Colombia-Meta-Lejanias,municipality,Colombia,Meta,Lejanias,NA,META,LEJANIAS,50400
+Colombia-Meta-Puerto_Concordia,municipality,Colombia,Meta,Puerto_Concordia,NA,META,PUERTO CONCORDIA,50450
+Colombia-Meta-Puerto_Gaitan,municipality,Colombia,Meta,Puerto_Gaitan,NA,META,PUERTO GAITAN,50568
+Colombia-Meta-Puerto_Lopez,municipality,Colombia,Meta,Puerto_Lopez,NA,META,PUERTO LOPEZ,50573
+Colombia-Meta-Puerto_Lleras,municipality,Colombia,Meta,Puerto_Lleras,NA,META,PUERTO LLERAS,50577
+Colombia-Meta-Puerto_Rico,municipality,Colombia,Meta,Puerto_Rico,NA,META,PUERTO RICO,50590
+Colombia-Meta-Restrepo,municipality,Colombia,Meta,Restrepo,NA,META,RESTREPO,50606
+Colombia-Meta-San_Carlos_De_Guaroa,municipality,Colombia,Meta,San_Carlos_De_Guaroa,NA,META,SAN CARLOS DE GUAROA,50680
+Colombia-Meta-San_Juan_De_Arama,municipality,Colombia,Meta,San_Juan_De_Arama,NA,META,SAN JUAN DE ARAMA,50683
+Colombia-Meta-San_Juanito,municipality,Colombia,Meta,San_Juanito,NA,META,SAN JUANITO,50686
+Colombia-Meta-San_Martin,municipality,Colombia,Meta,San_Martin,NA,META,SAN MARTIN,50689
+Colombia-Meta-Vistahermosa,municipality,Colombia,Meta,Vistahermosa,NA,META,VISTAHERMOSA,50711
+Colombia-Narino-Unknown,municipality,Colombia,Narino,Unknown,NA,NARIÑO,* NARIÑO. MUNICIPIO DESCONOCIDO,52000
+Colombia-Narino-Pasto,municipality,Colombia,Narino,Pasto,NA,NARIÑO,PASTO,52001
+Colombia-Narino-Alban,municipality,Colombia,Narino,Alban,NA,NARIÑO,ALBAN,52019
+Colombia-Narino-Aldana,municipality,Colombia,Narino,Aldana,NA,NARIÑO,ALDANA,52022
+Colombia-Narino-Ancuya,municipality,Colombia,Narino,Ancuya,NA,NARIÑO,ANCUYA,52036
+Colombia-Narino-Arboleda,municipality,Colombia,Narino,Arboleda,NA,NARIÑO,ARBOLEDA,52051
+Colombia-Narino-Barbacoas,municipality,Colombia,Narino,Barbacoas,NA,NARIÑO,BARBACOAS,52079
+Colombia-Narino-Belen,municipality,Colombia,Narino,Belen,NA,NARIÑO,BELEN,52083
+Colombia-Narino-Buesaco,municipality,Colombia,Narino,Buesaco,NA,NARIÑO,BUESACO,52110
+Colombia-Narino-Colon,municipality,Colombia,Narino,Colon,NA,NARIÑO,COLON,52203
+Colombia-Narino-Consaca,municipality,Colombia,Narino,Consaca,NA,NARIÑO,CONSACA,52207
+Colombia-Narino-Contadero,municipality,Colombia,Narino,Contadero,NA,NARIÑO,CONTADERO,52210
+Colombia-Narino-Cordoba,municipality,Colombia,Narino,Cordoba,NA,NARIÑO,CORDOBA,52215
+Colombia-Narino-Cuaspud,municipality,Colombia,Narino,Cuaspud,NA,NARIÑO,CUASPUD,52224
+Colombia-Narino-Cumbal,municipality,Colombia,Narino,Cumbal,NA,NARIÑO,CUMBAL,52227
+Colombia-Narino-Cumbitara,municipality,Colombia,Narino,Cumbitara,NA,NARIÑO,CUMBITARA,52233
+Colombia-Narino-Chachagui,municipality,Colombia,Narino,Chachagui,NA,NARIÑO,CHACHAGUI,52240
+Colombia-Narino-El_Charco,municipality,Colombia,Narino,El_Charco,NA,NARIÑO,EL CHARCO,52250
+Colombia-Narino-El_Penol,municipality,Colombia,Narino,El_Penol,NA,NARIÑO,EL PEÑOL,52254
+Colombia-Narino-El_Rosario,municipality,Colombia,Narino,El_Rosario,NA,NARIÑO,EL ROSARIO,52256
+Colombia-Narino-El_Tablon_De_Gomez,municipality,Colombia,Narino,El_Tablon_De_Gomez,NA,NARIÑO,EL TABLON DE GOMEZ,52258
+Colombia-Narino-El_Tambo,municipality,Colombia,Narino,El_Tambo,NA,NARIÑO,EL TAMBO,52260
+Colombia-Narino-Funes,municipality,Colombia,Narino,Funes,NA,NARIÑO,FUNES,52287
+Colombia-Narino-Guachucal,municipality,Colombia,Narino,Guachucal,NA,NARIÑO,GUACHUCAL,52317
+Colombia-Narino-Guaitarilla,municipality,Colombia,Narino,Guaitarilla,NA,NARIÑO,GUAITARILLA,52320
+Colombia-Narino-Gualmatan,municipality,Colombia,Narino,Gualmatan,NA,NARIÑO,GUALMATAN,52323
+Colombia-Narino-Iles,municipality,Colombia,Narino,Iles,NA,NARIÑO,ILES,52352
+Colombia-Narino-Imues,municipality,Colombia,Narino,Imues,NA,NARIÑO,IMUES,52354
+Colombia-Narino-Ipiales,municipality,Colombia,Narino,Ipiales,NA,NARIÑO,IPIALES,52356
+Colombia-Narino-La_Cruz,municipality,Colombia,Narino,La_Cruz,NA,NARIÑO,LA CRUZ,52378
+Colombia-Narino-La_Florida,municipality,Colombia,Narino,La_Florida,NA,NARIÑO,LA FLORIDA,52381
+Colombia-Narino-La_Llanada,municipality,Colombia,Narino,La_Llanada,NA,NARIÑO,LA LLANADA,52385
+Colombia-Narino-La_Tola,municipality,Colombia,Narino,La_Tola,NA,NARIÑO,LA TOLA,52390
+Colombia-Narino-La_Union,municipality,Colombia,Narino,La_Union,NA,NARIÑO,LA UNION,52399
+Colombia-Narino-Leiva,municipality,Colombia,Narino,Leiva,NA,NARIÑO,LEIVA,52405
+Colombia-Narino-Linares,municipality,Colombia,Narino,Linares,NA,NARIÑO,LINARES,52411
+Colombia-Narino-Los_Andes,municipality,Colombia,Narino,Los_Andes,NA,NARIÑO,LOS ANDES,52418
+Colombia-Narino-Magsi,municipality,Colombia,Narino,Magsi,NA,NARIÑO,MAGSI,52427
+Colombia-Narino-Mallama,municipality,Colombia,Narino,Mallama,NA,NARIÑO,MALLAMA,52435
+Colombia-Narino-Mosquera,municipality,Colombia,Narino,Mosquera,NA,NARIÑO,MOSQUERA,52473
+Colombia-Narino-Narino,municipality,Colombia,Narino,Narino,NA,NARIÑO,NARIÑO,52480
+Colombia-Narino-Olaya_Herrera,municipality,Colombia,Narino,Olaya_Herrera,NA,NARIÑO,OLAYA HERRERA,52490
+Colombia-Narino-Ospina,municipality,Colombia,Narino,Ospina,NA,NARIÑO,OSPINA,52506
+Colombia-Narino-Francisco_Pizarro,municipality,Colombia,Narino,Francisco_Pizarro,NA,NARIÑO,FRANCISCO PIZARRO,52520
+Colombia-Narino-Policarpa,municipality,Colombia,Narino,Policarpa,NA,NARIÑO,POLICARPA,52540
+Colombia-Narino-Potosi,municipality,Colombia,Narino,Potosi,NA,NARIÑO,POTOSI,52560
+Colombia-Narino-Providencia,municipality,Colombia,Narino,Providencia,NA,NARIÑO,PROVIDENCIA,52565
+Colombia-Narino-Puerres,municipality,Colombia,Narino,Puerres,NA,NARIÑO,PUERRES,52573
+Colombia-Narino-Pupiales,municipality,Colombia,Narino,Pupiales,NA,NARIÑO,PUPIALES,52585
+Colombia-Narino-Ricaurte,municipality,Colombia,Narino,Ricaurte,NA,NARIÑO,RICAURTE,52612
+Colombia-Narino-Roberto_Payan,municipality,Colombia,Narino,Roberto_Payan,NA,NARIÑO,ROBERTO PAYAN,52621
+Colombia-Narino-Samaniego,municipality,Colombia,Narino,Samaniego,NA,NARIÑO,SAMANIEGO,52678
+Colombia-Narino-Sandona,municipality,Colombia,Narino,Sandona,NA,NARIÑO,SANDONA,52683
+Colombia-Narino-San_Bernardo,municipality,Colombia,Narino,San_Bernardo,NA,NARIÑO,SAN BERNARDO,52685
+Colombia-Narino-San_Lorenzo,municipality,Colombia,Narino,San_Lorenzo,NA,NARIÑO,SAN LORENZO,52687
+Colombia-Narino-San_Pablo,municipality,Colombia,Narino,San_Pablo,NA,NARIÑO,SAN PABLO,52693
+Colombia-Narino-San_Pedro_De_Cartago,municipality,Colombia,Narino,San_Pedro_De_Cartago,NA,NARIÑO,SAN PEDRO DE CARTAGO,52694
+Colombia-Narino-Santa_Barbara,municipality,Colombia,Narino,Santa_Barbara,NA,NARIÑO,SANTA BARBARA,52696
+Colombia-Narino-Santacruz,municipality,Colombia,Narino,Santacruz,NA,NARIÑO,SANTACRUZ,52699
+Colombia-Narino-Sapuyes,municipality,Colombia,Narino,Sapuyes,NA,NARIÑO,SAPUYES,52720
+Colombia-Narino-Taminango,municipality,Colombia,Narino,Taminango,NA,NARIÑO,TAMINANGO,52786
+Colombia-Narino-Tangua,municipality,Colombia,Narino,Tangua,NA,NARIÑO,TANGUA,52788
+Colombia-Narino-San_Andres_De_Tumaco,municipality,Colombia,Narino,San_Andres_De_Tumaco,NA,NARIÑO,SAN ANDRES DE TUMACO,52835
+Colombia-Narino-Tuquerres,municipality,Colombia,Narino,Tuquerres,NA,NARIÑO,TUQUERRES,52838
+Colombia-Narino-Yacuanquer,municipality,Colombia,Narino,Yacuanquer,NA,NARIÑO,YACUANQUER,52885
+Colombia-Norte_Santander-Unknown,municipality,Colombia,Norte_Santander,Unknown,NA,NORTE SANTANDER,* N. DE SANTANDER. MUNICIPIO DESCONOCIDO,54000
+Colombia-Norte_Santander-Cucuta,municipality,Colombia,Norte_Santander,Cucuta,NA,NORTE SANTANDER,CUCUTA,54001
+Colombia-Norte_Santander-Abrego,municipality,Colombia,Norte_Santander,Abrego,NA,NORTE SANTANDER,ABREGO,54003
+Colombia-Norte_Santander-Arboledas,municipality,Colombia,Norte_Santander,Arboledas,NA,NORTE SANTANDER,ARBOLEDAS,54051
+Colombia-Norte_Santander-Bochalema,municipality,Colombia,Norte_Santander,Bochalema,NA,NORTE SANTANDER,BOCHALEMA,54099
+Colombia-Norte_Santander-Bucarasica,municipality,Colombia,Norte_Santander,Bucarasica,NA,NORTE SANTANDER,BUCARASICA,54109
+Colombia-Norte_Santander-Cacota,municipality,Colombia,Norte_Santander,Cacota,NA,NORTE SANTANDER,CACOTA,54125
+Colombia-Norte_Santander-Cachira,municipality,Colombia,Norte_Santander,Cachira,NA,NORTE SANTANDER,CACHIRA,54128
+Colombia-Norte_Santander-Chinacota,municipality,Colombia,Norte_Santander,Chinacota,NA,NORTE SANTANDER,CHINACOTA,54172
+Colombia-Norte_Santander-Chitaga,municipality,Colombia,Norte_Santander,Chitaga,NA,NORTE SANTANDER,CHITAGA,54174
+Colombia-Norte_Santander-Convencion,municipality,Colombia,Norte_Santander,Convencion,NA,NORTE SANTANDER,CONVENCION,54206
+Colombia-Norte_Santander-Cucutilla,municipality,Colombia,Norte_Santander,Cucutilla,NA,NORTE SANTANDER,CUCUTILLA,54223
+Colombia-Norte_Santander-Durania,municipality,Colombia,Norte_Santander,Durania,NA,NORTE SANTANDER,DURANIA,54239
+Colombia-Norte_Santander-El_Carmen,municipality,Colombia,Norte_Santander,El_Carmen,NA,NORTE SANTANDER,EL CARMEN,54245
+Colombia-Norte_Santander-El_Tarra,municipality,Colombia,Norte_Santander,El_Tarra,NA,NORTE SANTANDER,EL TARRA,54250
+Colombia-Norte_Santander-El_Zulia,municipality,Colombia,Norte_Santander,El_Zulia,NA,NORTE SANTANDER,EL ZULIA,54261
+Colombia-Norte_Santander-Gramalote,municipality,Colombia,Norte_Santander,Gramalote,NA,NORTE SANTANDER,GRAMALOTE,54313
+Colombia-Norte_Santander-Hacari,municipality,Colombia,Norte_Santander,Hacari,NA,NORTE SANTANDER,HACARI,54344
+Colombia-Norte_Santander-Herran,municipality,Colombia,Norte_Santander,Herran,NA,NORTE SANTANDER,HERRAN,54347
+Colombia-Norte_Santander-Labateca,municipality,Colombia,Norte_Santander,Labateca,NA,NORTE SANTANDER,LABATECA,54377
+Colombia-Norte_Santander-La_Esperanza,municipality,Colombia,Norte_Santander,La_Esperanza,NA,NORTE SANTANDER,LA ESPERANZA,54385
+Colombia-Norte_Santander-La_Playa,municipality,Colombia,Norte_Santander,La_Playa,NA,NORTE SANTANDER,LA PLAYA,54398
+Colombia-Norte_Santander-Los_Patios,municipality,Colombia,Norte_Santander,Los_Patios,NA,NORTE SANTANDER,LOS PATIOS,54405
+Colombia-Norte_Santander-Lourdes,municipality,Colombia,Norte_Santander,Lourdes,NA,NORTE SANTANDER,LOURDES,54418
+Colombia-Norte_Santander-Mutiscua,municipality,Colombia,Norte_Santander,Mutiscua,NA,NORTE SANTANDER,MUTISCUA,54480
+Colombia-Norte_Santander-Ocana,municipality,Colombia,Norte_Santander,Ocana,NA,NORTE SANTANDER,OCAÑA,54498
+Colombia-Norte_Santander-Pamplona,municipality,Colombia,Norte_Santander,Pamplona,NA,NORTE SANTANDER,PAMPLONA,54518
+Colombia-Norte_Santander-Pamplonita,municipality,Colombia,Norte_Santander,Pamplonita,NA,NORTE SANTANDER,PAMPLONITA,54520
+Colombia-Norte_Santander-Puerto_Santander,municipality,Colombia,Norte_Santander,Puerto_Santander,NA,NORTE SANTANDER,PUERTO SANTANDER,54553
+Colombia-Norte_Santander-Ragonvalia,municipality,Colombia,Norte_Santander,Ragonvalia,NA,NORTE SANTANDER,RAGONVALIA,54599
+Colombia-Norte_Santander-Salazar,municipality,Colombia,Norte_Santander,Salazar,NA,NORTE SANTANDER,SALAZAR,54660
+Colombia-Norte_Santander-San_Calixto,municipality,Colombia,Norte_Santander,San_Calixto,NA,NORTE SANTANDER,SAN CALIXTO,54670
+Colombia-Norte_Santander-San_Cayetano,municipality,Colombia,Norte_Santander,San_Cayetano,NA,NORTE SANTANDER,SAN CAYETANO,54673
+Colombia-Norte_Santander-Santiago,municipality,Colombia,Norte_Santander,Santiago,NA,NORTE SANTANDER,SANTIAGO,54680
+Colombia-Norte_Santander-Sardinata,municipality,Colombia,Norte_Santander,Sardinata,NA,NORTE SANTANDER,SARDINATA,54720
+Colombia-Norte_Santander-Silos,municipality,Colombia,Norte_Santander,Silos,NA,NORTE SANTANDER,SILOS,54743
+Colombia-Norte_Santander-Teorama,municipality,Colombia,Norte_Santander,Teorama,NA,NORTE SANTANDER,TEORAMA,54800
+Colombia-Norte_Santander-Tibu,municipality,Colombia,Norte_Santander,Tibu,NA,NORTE SANTANDER,TIBU,54810
+Colombia-Norte_Santander-Toledo,municipality,Colombia,Norte_Santander,Toledo,NA,NORTE SANTANDER,TOLEDO,54820
+Colombia-Norte_Santander-Villa_Caro,municipality,Colombia,Norte_Santander,Villa_Caro,NA,NORTE SANTANDER,VILLA CARO,54871
+Colombia-Norte_Santander-Villa_Del_Rosario,municipality,Colombia,Norte_Santander,Villa_Del_Rosario,NA,NORTE SANTANDER,VILLA DEL ROSARIO,54874
+Colombia-Quindio-Unknown,municipality,Colombia,Quindio,Unknown,NA,QUINDIO,* QUINDIO. MUNICIPIO DESCONOCIDO,63000
+Colombia-Quindio-Armenia,municipality,Colombia,Quindio,Armenia,NA,QUINDIO,ARMENIA,63001
+Colombia-Quindio-Buenavista,municipality,Colombia,Quindio,Buenavista,NA,QUINDIO,BUENAVISTA,63111
+Colombia-Quindio-Calarca,municipality,Colombia,Quindio,Calarca,NA,QUINDIO,CALARCA,63130
+Colombia-Quindio-Circasia,municipality,Colombia,Quindio,Circasia,NA,QUINDIO,CIRCASIA,63190
+Colombia-Quindio-Cordoba,municipality,Colombia,Quindio,Cordoba,NA,QUINDIO,CORDOBA,63212
+Colombia-Quindio-Filandia,municipality,Colombia,Quindio,Filandia,NA,QUINDIO,FILANDIA,63272
+Colombia-Quindio-Genova,municipality,Colombia,Quindio,Genova,NA,QUINDIO,GENOVA,63302
+Colombia-Quindio-La_Tebaida,municipality,Colombia,Quindio,La_Tebaida,NA,QUINDIO,LA TEBAIDA,63401
+Colombia-Quindio-Montenegro,municipality,Colombia,Quindio,Montenegro,NA,QUINDIO,MONTENEGRO,63470
+Colombia-Quindio-Pijao,municipality,Colombia,Quindio,Pijao,NA,QUINDIO,PIJAO,63548
+Colombia-Quindio-Quimbaya,municipality,Colombia,Quindio,Quimbaya,NA,QUINDIO,QUIMBAYA,63594
+Colombia-Quindio-Salento,municipality,Colombia,Quindio,Salento,NA,QUINDIO,SALENTO,63690
+Colombia-Risaralda-Unknown,municipality,Colombia,Risaralda,Unknown,NA,RISARALDA,* RISARALDA. MUNICIPIO DESCONOCIDO,66000
+Colombia-Risaralda-Pereira,municipality,Colombia,Risaralda,Pereira,NA,RISARALDA,PEREIRA,66001
+Colombia-Risaralda-Apia,municipality,Colombia,Risaralda,Apia,NA,RISARALDA,APIA,66045
+Colombia-Risaralda-Balboa,municipality,Colombia,Risaralda,Balboa,NA,RISARALDA,BALBOA,66075
+Colombia-Risaralda-Belen_De_Umbria,municipality,Colombia,Risaralda,Belen_De_Umbria,NA,RISARALDA,BELEN DE UMBRIA,66088
+Colombia-Risaralda-Dosquebradas,municipality,Colombia,Risaralda,Dosquebradas,NA,RISARALDA,DOSQUEBRADAS,66170
+Colombia-Risaralda-Guatica,municipality,Colombia,Risaralda,Guatica,NA,RISARALDA,GUATICA,66318
+Colombia-Risaralda-La_Celia,municipality,Colombia,Risaralda,La_Celia,NA,RISARALDA,LA CELIA,66383
+Colombia-Risaralda-La_Virginia,municipality,Colombia,Risaralda,La_Virginia,NA,RISARALDA,LA VIRGINIA,66400
+Colombia-Risaralda-Marsella,municipality,Colombia,Risaralda,Marsella,NA,RISARALDA,MARSELLA,66440
+Colombia-Risaralda-Mistrato,municipality,Colombia,Risaralda,Mistrato,NA,RISARALDA,MISTRATO,66456
+Colombia-Risaralda-Pueblo_Rico,municipality,Colombia,Risaralda,Pueblo_Rico,NA,RISARALDA,PUEBLO RICO,66572
+Colombia-Risaralda-Quinchia,municipality,Colombia,Risaralda,Quinchia,NA,RISARALDA,QUINCHIA,66594
+Colombia-Risaralda-Santa_Rosa_De_Cabal,municipality,Colombia,Risaralda,Santa_Rosa_De_Cabal,NA,RISARALDA,SANTA ROSA DE CABAL,66682
+Colombia-Risaralda-Santuario,municipality,Colombia,Risaralda,Santuario,NA,RISARALDA,SANTUARIO,66687
+Colombia-Santander-Unknown,municipality,Colombia,Santander,Unknown,NA,SANTANDER,* SANTANDER. MUNICIPIO DESCONOCIDO,68000
+Colombia-Santander-Bucaramanga,municipality,Colombia,Santander,Bucaramanga,NA,SANTANDER,BUCARAMANGA,68001
+Colombia-Santander-Aguada,municipality,Colombia,Santander,Aguada,NA,SANTANDER,AGUADA,68013
+Colombia-Santander-Albania,municipality,Colombia,Santander,Albania,NA,SANTANDER,ALBANIA,68020
+Colombia-Santander-Aratoca,municipality,Colombia,Santander,Aratoca,NA,SANTANDER,ARATOCA,68051
+Colombia-Santander-Barbosa,municipality,Colombia,Santander,Barbosa,NA,SANTANDER,BARBOSA,68077
+Colombia-Santander-Barichara,municipality,Colombia,Santander,Barichara,NA,SANTANDER,BARICHARA,68079
+Colombia-Santander-Barrancabermeja,municipality,Colombia,Santander,Barrancabermeja,NA,SANTANDER,BARRANCABERMEJA,68081
+Colombia-Santander-Betulia,municipality,Colombia,Santander,Betulia,NA,SANTANDER,BETULIA,68092
+Colombia-Santander-Bolivar,municipality,Colombia,Santander,Bolivar,NA,SANTANDER,BOLIVAR,68101
+Colombia-Santander-Cabrera,municipality,Colombia,Santander,Cabrera,NA,SANTANDER,CABRERA,68121
+Colombia-Santander-California,municipality,Colombia,Santander,California,NA,SANTANDER,CALIFORNIA,68132
+Colombia-Santander-Capitanejo,municipality,Colombia,Santander,Capitanejo,NA,SANTANDER,CAPITANEJO,68147
+Colombia-Santander-Carcasi,municipality,Colombia,Santander,Carcasi,NA,SANTANDER,CARCASI,68152
+Colombia-Santander-Cepita,municipality,Colombia,Santander,Cepita,NA,SANTANDER,CEPITA,68160
+Colombia-Santander-Cerrito,municipality,Colombia,Santander,Cerrito,NA,SANTANDER,CERRITO,68162
+Colombia-Santander-Charala,municipality,Colombia,Santander,Charala,NA,SANTANDER,CHARALA,68167
+Colombia-Santander-Charta,municipality,Colombia,Santander,Charta,NA,SANTANDER,CHARTA,68169
+Colombia-Santander-Chima,municipality,Colombia,Santander,Chima,NA,SANTANDER,CHIMA,68176
+Colombia-Santander-Chipata,municipality,Colombia,Santander,Chipata,NA,SANTANDER,CHIPATA,68179
+Colombia-Santander-Cimitarra,municipality,Colombia,Santander,Cimitarra,NA,SANTANDER,CIMITARRA,68190
+Colombia-Santander-Concepcion,municipality,Colombia,Santander,Concepcion,NA,SANTANDER,CONCEPCION,68207
+Colombia-Santander-Confines,municipality,Colombia,Santander,Confines,NA,SANTANDER,CONFINES,68209
+Colombia-Santander-Contratacion,municipality,Colombia,Santander,Contratacion,NA,SANTANDER,CONTRATACION,68211
+Colombia-Santander-Coromoro,municipality,Colombia,Santander,Coromoro,NA,SANTANDER,COROMORO,68217
+Colombia-Santander-Curiti,municipality,Colombia,Santander,Curiti,NA,SANTANDER,CURITI,68229
+Colombia-Santander-El_Carmen_De_Chucuri,municipality,Colombia,Santander,El_Carmen_De_Chucuri,NA,SANTANDER,EL CARMEN DE CHUCURI,68235
+Colombia-Santander-El_Guacamayo,municipality,Colombia,Santander,El_Guacamayo,NA,SANTANDER,EL GUACAMAYO,68245
+Colombia-Santander-El_Penon,municipality,Colombia,Santander,El_Penon,NA,SANTANDER,EL PEÑON,68250
+Colombia-Santander-El_Playon,municipality,Colombia,Santander,El_Playon,NA,SANTANDER,EL PLAYON,68255
+Colombia-Santander-Encino,municipality,Colombia,Santander,Encino,NA,SANTANDER,ENCINO,68264
+Colombia-Santander-Enciso,municipality,Colombia,Santander,Enciso,NA,SANTANDER,ENCISO,68266
+Colombia-Santander-Florian,municipality,Colombia,Santander,Florian,NA,SANTANDER,FLORIAN,68271
+Colombia-Santander-Floridablanca,municipality,Colombia,Santander,Floridablanca,NA,SANTANDER,FLORIDABLANCA,68276
+Colombia-Santander-Galan,municipality,Colombia,Santander,Galan,NA,SANTANDER,GALAN,68296
+Colombia-Santander-Gambita,municipality,Colombia,Santander,Gambita,NA,SANTANDER,GAMBITA,68298
+Colombia-Santander-Giron,municipality,Colombia,Santander,Giron,NA,SANTANDER,GIRON,68307
+Colombia-Santander-Guaca,municipality,Colombia,Santander,Guaca,NA,SANTANDER,GUACA,68318
+Colombia-Santander-Guadalupe,municipality,Colombia,Santander,Guadalupe,NA,SANTANDER,GUADALUPE,68320
+Colombia-Santander-Guapota,municipality,Colombia,Santander,Guapota,NA,SANTANDER,GUAPOTA,68322
+Colombia-Santander-Guavata,municipality,Colombia,Santander,Guavata,NA,SANTANDER,GUAVATA,68324
+Colombia-Santander-Gsepsa,municipality,Colombia,Santander,Gsepsa,NA,SANTANDER,GSEPSA,68327
+Colombia-Santander-Hato,municipality,Colombia,Santander,Hato,NA,SANTANDER,HATO,68344
+Colombia-Santander-Jesus_Maria,municipality,Colombia,Santander,Jesus_Maria,NA,SANTANDER,JESUS MARIA,68368
+Colombia-Santander-Jordan,municipality,Colombia,Santander,Jordan,NA,SANTANDER,JORDAN,68370
+Colombia-Santander-La_Belleza,municipality,Colombia,Santander,La_Belleza,NA,SANTANDER,LA BELLEZA,68377
+Colombia-Santander-Landazuri,municipality,Colombia,Santander,Landazuri,NA,SANTANDER,LANDAZURI,68385
+Colombia-Santander-La_Paz,municipality,Colombia,Santander,La_Paz,NA,SANTANDER,LA PAZ,68397
+Colombia-Santander-Lebrija,municipality,Colombia,Santander,Lebrija,NA,SANTANDER,LEBRIJA,68406
+Colombia-Santander-Los_Santos,municipality,Colombia,Santander,Los_Santos,NA,SANTANDER,LOS SANTOS,68418
+Colombia-Santander-Macaravita,municipality,Colombia,Santander,Macaravita,NA,SANTANDER,MACARAVITA,68425
+Colombia-Santander-Malaga,municipality,Colombia,Santander,Malaga,NA,SANTANDER,MALAGA,68432
+Colombia-Santander-Matanza,municipality,Colombia,Santander,Matanza,NA,SANTANDER,MATANZA,68444
+Colombia-Santander-Mogotes,municipality,Colombia,Santander,Mogotes,NA,SANTANDER,MOGOTES,68464
+Colombia-Santander-Molagavita,municipality,Colombia,Santander,Molagavita,NA,SANTANDER,MOLAGAVITA,68468
+Colombia-Santander-Ocamonte,municipality,Colombia,Santander,Ocamonte,NA,SANTANDER,OCAMONTE,68498
+Colombia-Santander-Oiba,municipality,Colombia,Santander,Oiba,NA,SANTANDER,OIBA,68500
+Colombia-Santander-Onzaga,municipality,Colombia,Santander,Onzaga,NA,SANTANDER,ONZAGA,68502
+Colombia-Santander-Palmar,municipality,Colombia,Santander,Palmar,NA,SANTANDER,PALMAR,68522
+Colombia-Santander-Palmas_Del_Socorro,municipality,Colombia,Santander,Palmas_Del_Socorro,NA,SANTANDER,PALMAS DEL SOCORRO,68524
+Colombia-Santander-Paramo,municipality,Colombia,Santander,Paramo,NA,SANTANDER,PARAMO,68533
+Colombia-Santander-Piedecuesta,municipality,Colombia,Santander,Piedecuesta,NA,SANTANDER,PIEDECUESTA,68547
+Colombia-Santander-Pinchote,municipality,Colombia,Santander,Pinchote,NA,SANTANDER,PINCHOTE,68549
+Colombia-Santander-Puente_Nacional,municipality,Colombia,Santander,Puente_Nacional,NA,SANTANDER,PUENTE NACIONAL,68572
+Colombia-Santander-Puerto_Parra,municipality,Colombia,Santander,Puerto_Parra,NA,SANTANDER,PUERTO PARRA,68573
+Colombia-Santander-Puerto_Wilches,municipality,Colombia,Santander,Puerto_Wilches,NA,SANTANDER,PUERTO WILCHES,68575
+Colombia-Santander-Rionegro,municipality,Colombia,Santander,Rionegro,NA,SANTANDER,RIONEGRO,68615
+Colombia-Santander-Sabana_De_Torres,municipality,Colombia,Santander,Sabana_De_Torres,NA,SANTANDER,SABANA DE TORRES,68655
+Colombia-Santander-San_Andres,municipality,Colombia,Santander,San_Andres,NA,SANTANDER,SAN ANDRES,68669
+Colombia-Santander-San_Benito,municipality,Colombia,Santander,San_Benito,NA,SANTANDER,SAN BENITO,68673
+Colombia-Santander-San_Gil,municipality,Colombia,Santander,San_Gil,NA,SANTANDER,SAN GIL,68679
+Colombia-Santander-San_Joaquin,municipality,Colombia,Santander,San_Joaquin,NA,SANTANDER,SAN JOAQUIN,68682
+Colombia-Santander-San_Jose_De_Miranda,municipality,Colombia,Santander,San_Jose_De_Miranda,NA,SANTANDER,SAN JOSE DE MIRANDA,68684
+Colombia-Santander-San_Miguel,municipality,Colombia,Santander,San_Miguel,NA,SANTANDER,SAN MIGUEL,68686
+Colombia-Santander-San_Vicente_De_Chucuri,municipality,Colombia,Santander,San_Vicente_De_Chucuri,NA,SANTANDER,SAN VICENTE DE CHUCURI,68689
+Colombia-Santander-Santa_Barbara,municipality,Colombia,Santander,Santa_Barbara,NA,SANTANDER,SANTA BARBARA,68705
+Colombia-Santander-Santa_Helena_Del_Opon,municipality,Colombia,Santander,Santa_Helena_Del_Opon,NA,SANTANDER,SANTA HELENA DEL OPON,68720
+Colombia-Santander-Simacota,municipality,Colombia,Santander,Simacota,NA,SANTANDER,SIMACOTA,68745
+Colombia-Santander-Socorro,municipality,Colombia,Santander,Socorro,NA,SANTANDER,SOCORRO,68755
+Colombia-Santander-Suaita,municipality,Colombia,Santander,Suaita,NA,SANTANDER,SUAITA,68770
+Colombia-Santander-Sucre,municipality,Colombia,Santander,Sucre,NA,SANTANDER,SUCRE,68773
+Colombia-Santander-Surata,municipality,Colombia,Santander,Surata,NA,SANTANDER,SURATA,68780
+Colombia-Santander-Tona,municipality,Colombia,Santander,Tona,NA,SANTANDER,TONA,68820
+Colombia-Santander-Valle_De_San_Jose,municipality,Colombia,Santander,Valle_De_San_Jose,NA,SANTANDER,VALLE DE SAN JOSE,68855
+Colombia-Santander-Velez,municipality,Colombia,Santander,Velez,NA,SANTANDER,VELEZ,68861
+Colombia-Santander-Vetas,municipality,Colombia,Santander,Vetas,NA,SANTANDER,VETAS,68867
+Colombia-Santander-Villanueva,municipality,Colombia,Santander,Villanueva,NA,SANTANDER,VILLANUEVA,68872
+Colombia-Santander-Zapatoca,municipality,Colombia,Santander,Zapatoca,NA,SANTANDER,ZAPATOCA,68895
+Colombia-Sucre-Unknown,municipality,Colombia,Sucre,Unknown,NA,SUCRE,* SUCRE. MUNICIPIO DESCONOCIDO,70000
+Colombia-Sucre-Sincelejo,municipality,Colombia,Sucre,Sincelejo,NA,SUCRE,SINCELEJO,70001
+Colombia-Sucre-Buenavista,municipality,Colombia,Sucre,Buenavista,NA,SUCRE,BUENAVISTA,70110
+Colombia-Sucre-Caimito,municipality,Colombia,Sucre,Caimito,NA,SUCRE,CAIMITO,70124
+Colombia-Sucre-Coloso,municipality,Colombia,Sucre,Coloso,NA,SUCRE,COLOSO,70204
+Colombia-Sucre-Corozal,municipality,Colombia,Sucre,Corozal,NA,SUCRE,COROZAL,70215
+Colombia-Sucre-Covenas,municipality,Colombia,Sucre,Covenas,NA,SUCRE,COVEÑAS,70221
+Colombia-Sucre-Chalan,municipality,Colombia,Sucre,Chalan,NA,SUCRE,CHALAN,70230
+Colombia-Sucre-El_Roble,municipality,Colombia,Sucre,El_Roble,NA,SUCRE,EL ROBLE,70233
+Colombia-Sucre-Galeras,municipality,Colombia,Sucre,Galeras,NA,SUCRE,GALERAS,70235
+Colombia-Sucre-Guaranda,municipality,Colombia,Sucre,Guaranda,NA,SUCRE,GUARANDA,70265
+Colombia-Sucre-La_Union,municipality,Colombia,Sucre,La_Union,NA,SUCRE,LA UNION,70400
+Colombia-Sucre-Los_Palmitos,municipality,Colombia,Sucre,Los_Palmitos,NA,SUCRE,LOS PALMITOS,70418
+Colombia-Sucre-Majagual,municipality,Colombia,Sucre,Majagual,NA,SUCRE,MAJAGUAL,70429
+Colombia-Sucre-Morroa,municipality,Colombia,Sucre,Morroa,NA,SUCRE,MORROA,70473
+Colombia-Sucre-Ovejas,municipality,Colombia,Sucre,Ovejas,NA,SUCRE,OVEJAS,70508
+Colombia-Sucre-Palmito,municipality,Colombia,Sucre,Palmito,NA,SUCRE,PALMITO,70523
+Colombia-Sucre-Sampues,municipality,Colombia,Sucre,Sampues,NA,SUCRE,SAMPUES,70670
+Colombia-Sucre-San_Benito_Abad,municipality,Colombia,Sucre,San_Benito_Abad,NA,SUCRE,SAN BENITO ABAD,70678
+Colombia-Sucre-San_Juan_De_Betulia,municipality,Colombia,Sucre,San_Juan_De_Betulia,NA,SUCRE,SAN JUAN DE BETULIA,70702
+Colombia-Sucre-San_Marcos,municipality,Colombia,Sucre,San_Marcos,NA,SUCRE,SAN MARCOS,70708
+Colombia-Sucre-San_Onofre,municipality,Colombia,Sucre,San_Onofre,NA,SUCRE,SAN ONOFRE,70713
+Colombia-Sucre-San_Pedro,municipality,Colombia,Sucre,San_Pedro,NA,SUCRE,SAN PEDRO,70717
+Colombia-Sucre-San_Luis_De_Since,municipality,Colombia,Sucre,San_Luis_De_Since,NA,SUCRE,SAN LUIS DE SINCE,70742
+Colombia-Sucre-Sucre,municipality,Colombia,Sucre,Sucre,NA,SUCRE,SUCRE,70771
+Colombia-Sucre-Tolu,municipality,Colombia,Sucre,Tolu,NA,SUCRE,TOLU,70820
+Colombia-Sucre-Toluviejo,municipality,Colombia,Sucre,Toluviejo,NA,SUCRE,TOLUVIEJO,70823
+Colombia-Tolima-Unknown,municipality,Colombia,Tolima,Unknown,NA,TOLIMA,* TOLIMA. MUNICIPIO DESCONOCIDO,73000
+Colombia-Tolima-Ibague,municipality,Colombia,Tolima,Ibague,NA,TOLIMA,IBAGUE,73001
+Colombia-Tolima-Alpujarra,municipality,Colombia,Tolima,Alpujarra,NA,TOLIMA,ALPUJARRA,73024
+Colombia-Tolima-Alvarado,municipality,Colombia,Tolima,Alvarado,NA,TOLIMA,ALVARADO,73026
+Colombia-Tolima-Ambalema,municipality,Colombia,Tolima,Ambalema,NA,TOLIMA,AMBALEMA,73030
+Colombia-Tolima-Anzoategui,municipality,Colombia,Tolima,Anzoategui,NA,TOLIMA,ANZOATEGUI,73043
+Colombia-Tolima-Armero_(Guayabal),municipality,Colombia,Tolima,Armero_(Guayabal),NA,TOLIMA,ARMERO (GUAYABAL),73055
+Colombia-Tolima-Ataco,municipality,Colombia,Tolima,Ataco,NA,TOLIMA,ATACO,73067
+Colombia-Tolima-Cajamarca,municipality,Colombia,Tolima,Cajamarca,NA,TOLIMA,CAJAMARCA,73124
+Colombia-Tolima-Carmen_De_Apicala,municipality,Colombia,Tolima,Carmen_De_Apicala,NA,TOLIMA,CARMEN DE APICALA,73148
+Colombia-Tolima-Casabianca,municipality,Colombia,Tolima,Casabianca,NA,TOLIMA,CASABIANCA,73152
+Colombia-Tolima-Chaparral,municipality,Colombia,Tolima,Chaparral,NA,TOLIMA,CHAPARRAL,73168
+Colombia-Tolima-Coello,municipality,Colombia,Tolima,Coello,NA,TOLIMA,COELLO,73200
+Colombia-Tolima-Coyaima,municipality,Colombia,Tolima,Coyaima,NA,TOLIMA,COYAIMA,73217
+Colombia-Tolima-Cunday,municipality,Colombia,Tolima,Cunday,NA,TOLIMA,CUNDAY,73226
+Colombia-Tolima-Dolores,municipality,Colombia,Tolima,Dolores,NA,TOLIMA,DOLORES,73236
+Colombia-Tolima-Espinal,municipality,Colombia,Tolima,Espinal,NA,TOLIMA,ESPINAL,73268
+Colombia-Tolima-Falan,municipality,Colombia,Tolima,Falan,NA,TOLIMA,FALAN,73270
+Colombia-Tolima-Flandes,municipality,Colombia,Tolima,Flandes,NA,TOLIMA,FLANDES,73275
+Colombia-Tolima-Fresno,municipality,Colombia,Tolima,Fresno,NA,TOLIMA,FRESNO,73283
+Colombia-Tolima-Guamo,municipality,Colombia,Tolima,Guamo,NA,TOLIMA,GUAMO,73319
+Colombia-Tolima-Herveo,municipality,Colombia,Tolima,Herveo,NA,TOLIMA,HERVEO,73347
+Colombia-Tolima-Honda,municipality,Colombia,Tolima,Honda,NA,TOLIMA,HONDA,73349
+Colombia-Tolima-Icononzo,municipality,Colombia,Tolima,Icononzo,NA,TOLIMA,ICONONZO,73352
+Colombia-Tolima-Lerida,municipality,Colombia,Tolima,Lerida,NA,TOLIMA,LERIDA,73408
+Colombia-Tolima-Libano,municipality,Colombia,Tolima,Libano,NA,TOLIMA,LIBANO,73411
+Colombia-Tolima-Mariquita,municipality,Colombia,Tolima,Mariquita,NA,TOLIMA,MARIQUITA,73443
+Colombia-Tolima-Melgar,municipality,Colombia,Tolima,Melgar,NA,TOLIMA,MELGAR,73449
+Colombia-Tolima-Murillo,municipality,Colombia,Tolima,Murillo,NA,TOLIMA,MURILLO,73461
+Colombia-Tolima-Natagaima,municipality,Colombia,Tolima,Natagaima,NA,TOLIMA,NATAGAIMA,73483
+Colombia-Tolima-Ortega,municipality,Colombia,Tolima,Ortega,NA,TOLIMA,ORTEGA,73504
+Colombia-Tolima-Palocabildo,municipality,Colombia,Tolima,Palocabildo,NA,TOLIMA,PALOCABILDO,73520
+Colombia-Tolima-Piedras,municipality,Colombia,Tolima,Piedras,NA,TOLIMA,PIEDRAS,73547
+Colombia-Tolima-Planadas,municipality,Colombia,Tolima,Planadas,NA,TOLIMA,PLANADAS,73555
+Colombia-Tolima-Prado,municipality,Colombia,Tolima,Prado,NA,TOLIMA,PRADO,73563
+Colombia-Tolima-Purificacion,municipality,Colombia,Tolima,Purificacion,NA,TOLIMA,PURIFICACION,73585
+Colombia-Tolima-Rioblanco,municipality,Colombia,Tolima,Rioblanco,NA,TOLIMA,RIOBLANCO,73616
+Colombia-Tolima-Roncesvalles,municipality,Colombia,Tolima,Roncesvalles,NA,TOLIMA,RONCESVALLES,73622
+Colombia-Tolima-Rovira,municipality,Colombia,Tolima,Rovira,NA,TOLIMA,ROVIRA,73624
+Colombia-Tolima-Saldana,municipality,Colombia,Tolima,Saldana,NA,TOLIMA,SALDAÑA,73671
+Colombia-Tolima-San_Antonio,municipality,Colombia,Tolima,San_Antonio,NA,TOLIMA,SAN ANTONIO,73675
+Colombia-Tolima-San_Luis,municipality,Colombia,Tolima,San_Luis,NA,TOLIMA,SAN LUIS,73678
+Colombia-Tolima-Santa_Isabel,municipality,Colombia,Tolima,Santa_Isabel,NA,TOLIMA,SANTA ISABEL,73686
+Colombia-Tolima-Suarez,municipality,Colombia,Tolima,Suarez,NA,TOLIMA,SUAREZ,73770
+Colombia-Tolima-Valle_De_San_Juan,municipality,Colombia,Tolima,Valle_De_San_Juan,NA,TOLIMA,VALLE DE SAN JUAN,73854
+Colombia-Tolima-Venadillo,municipality,Colombia,Tolima,Venadillo,NA,TOLIMA,VENADILLO,73861
+Colombia-Tolima-Villahermosa,municipality,Colombia,Tolima,Villahermosa,NA,TOLIMA,VILLAHERMOSA,73870
+Colombia-Tolima-Villarrica,municipality,Colombia,Tolima,Villarrica,NA,TOLIMA,VILLARRICA,73873
+Colombia-Valle_Del_Cauca-Unknown,municipality,Colombia,Valle_Del_Cauca,Unknown,NA,VALLE DEL CAUCA,* VALLE DEL CAUCA. MUNICIPIO DESCONOCIDO,76000
+Colombia-Valle_Del_Cauca-Cali,municipality,Colombia,Valle_Del_Cauca,Cali,NA,VALLE DEL CAUCA,CALI,76001
+Colombia-Valle_Del_Cauca-Alcala,municipality,Colombia,Valle_Del_Cauca,Alcala,NA,VALLE DEL CAUCA,ALCALA,76020
+Colombia-Valle_Del_Cauca-Andalucia,municipality,Colombia,Valle_Del_Cauca,Andalucia,NA,VALLE DEL CAUCA,ANDALUCIA,76036
+Colombia-Valle_Del_Cauca-Ansermanuevo,municipality,Colombia,Valle_Del_Cauca,Ansermanuevo,NA,VALLE DEL CAUCA,ANSERMANUEVO,76041
+Colombia-Valle_Del_Cauca-Argelia,municipality,Colombia,Valle_Del_Cauca,Argelia,NA,VALLE DEL CAUCA,ARGELIA,76054
+Colombia-Valle_Del_Cauca-Bolivar,municipality,Colombia,Valle_Del_Cauca,Bolivar,NA,VALLE DEL CAUCA,BOLIVAR,76100
+Colombia-Valle_Del_Cauca-Guadalajara_De_Buga,municipality,Colombia,Valle_Del_Cauca,Guadalajara_De_Buga,NA,VALLE DEL CAUCA,GUADALAJARA DE BUGA,76111
+Colombia-Valle_Del_Cauca-Bugalagrande,municipality,Colombia,Valle_Del_Cauca,Bugalagrande,NA,VALLE DEL CAUCA,BUGALAGRANDE,76113
+Colombia-Valle_Del_Cauca-Caicedonia,municipality,Colombia,Valle_Del_Cauca,Caicedonia,NA,VALLE DEL CAUCA,CAICEDONIA,76122
+Colombia-Valle_Del_Cauca-Calima,municipality,Colombia,Valle_Del_Cauca,Calima,NA,VALLE DEL CAUCA,CALIMA,76126
+Colombia-Valle_Del_Cauca-Candelaria,municipality,Colombia,Valle_Del_Cauca,Candelaria,NA,VALLE DEL CAUCA,CANDELARIA,76130
+Colombia-Valle_Del_Cauca-Cartago,municipality,Colombia,Valle_Del_Cauca,Cartago,NA,VALLE DEL CAUCA,CARTAGO,76147
+Colombia-Valle_Del_Cauca-Dagua,municipality,Colombia,Valle_Del_Cauca,Dagua,NA,VALLE DEL CAUCA,DAGUA,76233
+Colombia-Valle_Del_Cauca-El_Aguila,municipality,Colombia,Valle_Del_Cauca,El_Aguila,NA,VALLE DEL CAUCA,EL AGUILA,76243
+Colombia-Valle_Del_Cauca-El_Cairo,municipality,Colombia,Valle_Del_Cauca,El_Cairo,NA,VALLE DEL CAUCA,EL CAIRO,76246
+Colombia-Valle_Del_Cauca-El_Cerrito,municipality,Colombia,Valle_Del_Cauca,El_Cerrito,NA,VALLE DEL CAUCA,EL CERRITO,76248
+Colombia-Valle_Del_Cauca-El_Dovio,municipality,Colombia,Valle_Del_Cauca,El_Dovio,NA,VALLE DEL CAUCA,EL DOVIO,76250
+Colombia-Valle_Del_Cauca-Florida,municipality,Colombia,Valle_Del_Cauca,Florida,NA,VALLE DEL CAUCA,FLORIDA,76275
+Colombia-Valle_Del_Cauca-Ginebra,municipality,Colombia,Valle_Del_Cauca,Ginebra,NA,VALLE DEL CAUCA,GINEBRA,76306
+Colombia-Valle_Del_Cauca-Guacari,municipality,Colombia,Valle_Del_Cauca,Guacari,NA,VALLE DEL CAUCA,GUACARI,76318
+Colombia-Valle_Del_Cauca-Jamundi,municipality,Colombia,Valle_Del_Cauca,Jamundi,NA,VALLE DEL CAUCA,JAMUNDI,76364
+Colombia-Valle_Del_Cauca-La_Cumbre,municipality,Colombia,Valle_Del_Cauca,La_Cumbre,NA,VALLE DEL CAUCA,LA CUMBRE,76377
+Colombia-Valle_Del_Cauca-La_Union,municipality,Colombia,Valle_Del_Cauca,La_Union,NA,VALLE DEL CAUCA,LA UNION,76400
+Colombia-Valle_Del_Cauca-La_Victoria,municipality,Colombia,Valle_Del_Cauca,La_Victoria,NA,VALLE DEL CAUCA,LA VICTORIA,76403
+Colombia-Valle_Del_Cauca-Obando,municipality,Colombia,Valle_Del_Cauca,Obando,NA,VALLE DEL CAUCA,OBANDO,76497
+Colombia-Valle_Del_Cauca-Palmira,municipality,Colombia,Valle_Del_Cauca,Palmira,NA,VALLE DEL CAUCA,PALMIRA,76520
+Colombia-Valle_Del_Cauca-Pradera,municipality,Colombia,Valle_Del_Cauca,Pradera,NA,VALLE DEL CAUCA,PRADERA,76563
+Colombia-Valle_Del_Cauca-Restrepo,municipality,Colombia,Valle_Del_Cauca,Restrepo,NA,VALLE DEL CAUCA,RESTREPO,76606
+Colombia-Valle_Del_Cauca-Riofrio,municipality,Colombia,Valle_Del_Cauca,Riofrio,NA,VALLE DEL CAUCA,RIOFRIO,76616
+Colombia-Valle_Del_Cauca-Roldanillo,municipality,Colombia,Valle_Del_Cauca,Roldanillo,NA,VALLE DEL CAUCA,ROLDANILLO,76622
+Colombia-Valle_Del_Cauca-San_Pedro,municipality,Colombia,Valle_Del_Cauca,San_Pedro,NA,VALLE DEL CAUCA,SAN PEDRO,76670
+Colombia-Valle_Del_Cauca-Sevilla,municipality,Colombia,Valle_Del_Cauca,Sevilla,NA,VALLE DEL CAUCA,SEVILLA,76736
+Colombia-Valle_Del_Cauca-Toro,municipality,Colombia,Valle_Del_Cauca,Toro,NA,VALLE DEL CAUCA,TORO,76823
+Colombia-Valle_Del_Cauca-Trujillo,municipality,Colombia,Valle_Del_Cauca,Trujillo,NA,VALLE DEL CAUCA,TRUJILLO,76828
+Colombia-Valle_Del_Cauca-Tulua,municipality,Colombia,Valle_Del_Cauca,Tulua,NA,VALLE DEL CAUCA,TULUA,76834
+Colombia-Valle_Del_Cauca-Ulloa,municipality,Colombia,Valle_Del_Cauca,Ulloa,NA,VALLE DEL CAUCA,ULLOA,76845
+Colombia-Valle_Del_Cauca-Versalles,municipality,Colombia,Valle_Del_Cauca,Versalles,NA,VALLE DEL CAUCA,VERSALLES,76863
+Colombia-Valle_Del_Cauca-Vijes,municipality,Colombia,Valle_Del_Cauca,Vijes,NA,VALLE DEL CAUCA,VIJES,76869
+Colombia-Valle_Del_Cauca-Yotoco,municipality,Colombia,Valle_Del_Cauca,Yotoco,NA,VALLE DEL CAUCA,YOTOCO,76890
+Colombia-Valle_Del_Cauca-Yumbo,municipality,Colombia,Valle_Del_Cauca,Yumbo,NA,VALLE DEL CAUCA,YUMBO,76892
+Colombia-Valle_Del_Cauca-Zarzal,municipality,Colombia,Valle_Del_Cauca,Zarzal,NA,VALLE DEL CAUCA,ZARZAL,76895
+Colombia-Valle_Del_Cauca-Buenaventura,municipality,Colombia,Valle_Del_Cauca,Buenaventura,NA,VALLE DEL CAUCA,BUENAVENTURA,76109
+Colombia-Arauca-Unknown,municipality,Colombia,Arauca,Unknown,NA,ARAUCA,* ARAUCA. MUNICIPIO DESCONOCIDO,81000
+Colombia-Arauca-Arauca,municipality,Colombia,Arauca,Arauca,NA,ARAUCA,ARAUCA,81001
+Colombia-Arauca-Arauquita,municipality,Colombia,Arauca,Arauquita,NA,ARAUCA,ARAUQUITA,81065
+Colombia-Arauca-Cravo_Norte,municipality,Colombia,Arauca,Cravo_Norte,NA,ARAUCA,CRAVO NORTE,81220
+Colombia-Arauca-Fortul,municipality,Colombia,Arauca,Fortul,NA,ARAUCA,FORTUL,81300
+Colombia-Arauca-Puerto_Rondon,municipality,Colombia,Arauca,Puerto_Rondon,NA,ARAUCA,PUERTO RONDON,81591
+Colombia-Arauca-Saravena,municipality,Colombia,Arauca,Saravena,NA,ARAUCA,SARAVENA,81736
+Colombia-Arauca-Tame,municipality,Colombia,Arauca,Tame,NA,ARAUCA,TAME,81794
+Colombia-Casanare-Unknown,municipality,Colombia,Casanare,Unknown,NA,CASANARE,* CASANARE. MUNICIPIO DESCONOCIDO,85000
+Colombia-Casanare-Yopal,municipality,Colombia,Casanare,Yopal,NA,CASANARE,YOPAL,85001
+Colombia-Casanare-Aguazul,municipality,Colombia,Casanare,Aguazul,NA,CASANARE,AGUAZUL,85010
+Colombia-Casanare-Chameza,municipality,Colombia,Casanare,Chameza,NA,CASANARE,CHAMEZA,85015
+Colombia-Casanare-Hato_Corozal,municipality,Colombia,Casanare,Hato_Corozal,NA,CASANARE,HATO COROZAL,85125
+Colombia-Casanare-La_Salina,municipality,Colombia,Casanare,La_Salina,NA,CASANARE,LA SALINA,85136
+Colombia-Casanare-Mani,municipality,Colombia,Casanare,Mani,NA,CASANARE,MANI,85139
+Colombia-Casanare-Monterrey,municipality,Colombia,Casanare,Monterrey,NA,CASANARE,MONTERREY,85162
+Colombia-Casanare-Nunchia,municipality,Colombia,Casanare,Nunchia,NA,CASANARE,NUNCHIA,85225
+Colombia-Casanare-Orocue,municipality,Colombia,Casanare,Orocue,NA,CASANARE,OROCUE,85230
+Colombia-Casanare-Paz_De_Ariporo,municipality,Colombia,Casanare,Paz_De_Ariporo,NA,CASANARE,PAZ DE ARIPORO,85250
+Colombia-Casanare-Pore,municipality,Colombia,Casanare,Pore,NA,CASANARE,PORE,85263
+Colombia-Casanare-Recetor,municipality,Colombia,Casanare,Recetor,NA,CASANARE,RECETOR,85279
+Colombia-Casanare-Sabanalarga,municipality,Colombia,Casanare,Sabanalarga,NA,CASANARE,SABANALARGA,85300
+Colombia-Casanare-Sacama,municipality,Colombia,Casanare,Sacama,NA,CASANARE,SACAMA,85315
+Colombia-Casanare-San_Luis_De_Palenque,municipality,Colombia,Casanare,San_Luis_De_Palenque,NA,CASANARE,SAN LUIS DE PALENQUE,85325
+Colombia-Casanare-Tamara,municipality,Colombia,Casanare,Tamara,NA,CASANARE,TAMARA,85400
+Colombia-Casanare-Tauramena,municipality,Colombia,Casanare,Tauramena,NA,CASANARE,TAURAMENA,85410
+Colombia-Casanare-Trinidad,municipality,Colombia,Casanare,Trinidad,NA,CASANARE,TRINIDAD,85430
+Colombia-Casanare-Villanueva,municipality,Colombia,Casanare,Villanueva,NA,CASANARE,VILLANUEVA,85440
+Colombia-Putumayo-Unknown,municipality,Colombia,Putumayo,Unknown,NA,PUTUMAYO,* PUTUMAYO. MUNICIPIO DESCONOCIDO,86000
+Colombia-Putumayo-Mocoa,municipality,Colombia,Putumayo,Mocoa,NA,PUTUMAYO,MOCOA,86001
+Colombia-Putumayo-Colon,municipality,Colombia,Putumayo,Colon,NA,PUTUMAYO,COLON,86219
+Colombia-Putumayo-Orito,municipality,Colombia,Putumayo,Orito,NA,PUTUMAYO,ORITO,86320
+Colombia-Putumayo-Puerto_Asis,municipality,Colombia,Putumayo,Puerto_Asis,NA,PUTUMAYO,PUERTO ASIS,86568
+Colombia-Putumayo-Puerto_Caicedo,municipality,Colombia,Putumayo,Puerto_Caicedo,NA,PUTUMAYO,PUERTO CAICEDO,86569
+Colombia-Putumayo-Puerto_Guzman,municipality,Colombia,Putumayo,Puerto_Guzman,NA,PUTUMAYO,PUERTO GUZMAN,86571
+Colombia-Putumayo-Leguizamo,municipality,Colombia,Putumayo,Leguizamo,NA,PUTUMAYO,LEGUIZAMO,86573
+Colombia-Putumayo-Sibundoy,municipality,Colombia,Putumayo,Sibundoy,NA,PUTUMAYO,SIBUNDOY,86749
+Colombia-Putumayo-San_Francisco,municipality,Colombia,Putumayo,San_Francisco,NA,PUTUMAYO,SAN FRANCISCO,86755
+Colombia-Putumayo-San_Miguel,municipality,Colombia,Putumayo,San_Miguel,NA,PUTUMAYO,SAN MIGUEL,86757
+Colombia-Putumayo-Santiago,municipality,Colombia,Putumayo,Santiago,NA,PUTUMAYO,SANTIAGO,86760
+Colombia-Putumayo-Valle_Del_Guamuez,municipality,Colombia,Putumayo,Valle_Del_Guamuez,NA,PUTUMAYO,VALLE DEL GUAMUEZ,86865
+Colombia-Putumayo-Villagarzon,municipality,Colombia,Putumayo,Villagarzon,NA,PUTUMAYO,VILLAGARZON,86885
+Colombia-San_Andres-Unknown,municipality,Colombia,San_Andres,Unknown,NA,SAN ANDRES,* SAN ANDRES. MUNICIPIO DESCONOCIDO,88000
+Colombia-San_Andres-San_Andres,municipality,Colombia,San_Andres,San_Andres,NA,SAN ANDRES,SAN ANDRES,88001
+Colombia-San_Andres-Providencia,municipality,Colombia,San_Andres,Providencia,NA,SAN ANDRES,PROVIDENCIA,88564
+Colombia-Amazonas-Unknown,municipality,Colombia,Amazonas,Unknown,NA,AMAZONAS,* AMAZONAS. MUNICIPIO DESCONOCIDO,91000
+Colombia-Amazonas-Leticia,municipality,Colombia,Amazonas,Leticia,NA,AMAZONAS,LETICIA,91001
+Colombia-Amazonas-El_Encanto,municipality,Colombia,Amazonas,El_Encanto,NA,AMAZONAS,EL ENCANTO,91263
+Colombia-Amazonas-La_Chorrera,municipality,Colombia,Amazonas,La_Chorrera,NA,AMAZONAS,LA CHORRERA,91405
+Colombia-Amazonas-La_Pedrera,municipality,Colombia,Amazonas,La_Pedrera,NA,AMAZONAS,LA PEDRERA,91407
+Colombia-Amazonas-La_Victoria,municipality,Colombia,Amazonas,La_Victoria,NA,AMAZONAS,LA VICTORIA,91430
+Colombia-Amazonas-Miriti_Parana,municipality,Colombia,Amazonas,Miriti_Parana,NA,AMAZONAS,MIRITI - PARANA,91460
+Colombia-Amazonas-Puerto_Alegria,municipality,Colombia,Amazonas,Puerto_Alegria,NA,AMAZONAS,PUERTO ALEGRIA,91530
+Colombia-Amazonas-Puerto_Arica,municipality,Colombia,Amazonas,Puerto_Arica,NA,AMAZONAS,PUERTO ARICA,91536
+Colombia-Amazonas-Puerto_Narino,municipality,Colombia,Amazonas,Puerto_Narino,NA,AMAZONAS,PUERTO NARIÑO,91540
+Colombia-Amazonas-Puerto_Santander,municipality,Colombia,Amazonas,Puerto_Santander,NA,AMAZONAS,PUERTO SANTANDER,91669
+Colombia-Amazonas-Tarapaca,municipality,Colombia,Amazonas,Tarapaca,NA,AMAZONAS,TARAPACA,91798
+Colombia-Guainia-Unknown,municipality,Colombia,Guainia,Unknown,NA,GUAINIA,* GUAINIA. MUNICIPIO DESCONOCIDO,94000
+Colombia-Guainia-Inirida,municipality,Colombia,Guainia,Inirida,NA,GUAINIA,INIRIDA,94001
+Colombia-Guainia-Barranco_Minas,municipality,Colombia,Guainia,Barranco_Minas,NA,GUAINIA,BARRANCO MINAS,94343
+Colombia-Guainia-Mapiripana,municipality,Colombia,Guainia,Mapiripana,NA,GUAINIA,MAPIRIPANA,94663
+Colombia-Guainia-San_Felipe,municipality,Colombia,Guainia,San_Felipe,NA,GUAINIA,SAN FELIPE,94883
+Colombia-Guainia-Puerto_Colombia,municipality,Colombia,Guainia,Puerto_Colombia,NA,GUAINIA,PUERTO COLOMBIA,94884
+Colombia-Guainia-La_Guadalupe,municipality,Colombia,Guainia,La_Guadalupe,NA,GUAINIA,LA GUADALUPE,94885
+Colombia-Guainia-Cacahual,municipality,Colombia,Guainia,Cacahual,NA,GUAINIA,CACAHUAL,94886
+Colombia-Guainia-Pana_Pana,municipality,Colombia,Guainia,Pana_Pana,NA,GUAINIA,PANA PANA,94887
+Colombia-Guainia-Morichal,municipality,Colombia,Guainia,Morichal,NA,GUAINIA,MORICHAL,94888
+Colombia-Guaviare-Unknown,municipality,Colombia,Guaviare,Unknown,NA,GUAVIARE,* GUAVIARE. MUNICIPIO DESCONOCIDO,95000
+Colombia-Guaviare-San_Jose_Del_Guaviare,municipality,Colombia,Guaviare,San_Jose_Del_Guaviare,NA,GUAVIARE,SAN JOSE DEL GUAVIARE,95001
+Colombia-Guaviare-Calamar,municipality,Colombia,Guaviare,Calamar,NA,GUAVIARE,CALAMAR,95015
+Colombia-Guaviare-El_Retorno,municipality,Colombia,Guaviare,El_Retorno,NA,GUAVIARE,EL RETORNO,95025
+Colombia-Guaviare-Miraflores,municipality,Colombia,Guaviare,Miraflores,NA,GUAVIARE,MIRAFLORES,95200
+Colombia-Vaupes-Unknown,municipality,Colombia,Vaupes,Unknown,NA,VAUPES,* VAUPES. MUNICIPIO DESCONOCIDO,97000
+Colombia-Vaupes-Mitu,municipality,Colombia,Vaupes,Mitu,NA,VAUPES,MITU,97001
+Colombia-Vaupes-Caruru,municipality,Colombia,Vaupes,Caruru,NA,VAUPES,CARURU,97161
+Colombia-Vaupes-Pacoa,municipality,Colombia,Vaupes,Pacoa,NA,VAUPES,PACOA,97511
+Colombia-Vaupes-Taraira,municipality,Colombia,Vaupes,Taraira,NA,VAUPES,TARAIRA,97666
+Colombia-Vaupes-Papunaua,municipality,Colombia,Vaupes,Papunaua,NA,VAUPES,PAPUNAUA,97777
+Colombia-Vaupes-Yavarate,municipality,Colombia,Vaupes,Yavarate,NA,VAUPES,YAVARATE,97889
+Colombia-Vichada-Unknown,municipality,Colombia,Vichada,Unknown,NA,VICHADA,* VICHADA. MUNICIPIO DESCONOCIDO,99000
+Colombia-Vichada-Puerto_Carreno,municipality,Colombia,Vichada,Puerto_Carreno,NA,VICHADA,PUERTO CARREÑO,99001
+Colombia-Vichada-La_Primavera,municipality,Colombia,Vichada,La_Primavera,NA,VICHADA,LA PRIMAVERA,99524
+Colombia-Vichada-Santa_Rosalia,municipality,Colombia,Vichada,Santa_Rosalia,NA,VICHADA,SANTA ROSALIA,99624
+Colombia-Vichada-Cumaribo,municipality,Colombia,Vichada,Cumaribo,NA,VICHADA,CUMARIBO,99773
+Colombia-unknown-unknown,municipality,Colombia,unknown,unknown,NA,NA,NA,
+Colombia-Valle,province,Colombia,Valle,NA,NA,NA,NA,
+Colombia-Norte_Santander,province,Colombia,NorteSantander,NA,NA,NA,NA,
+Colombia-Barranquilla,province,Colombia,Barranquilla,NA,NA,NA,NA,
+Colombia-Huila,province,Colombia,Huila,NA,NA,NA,NA,
+Colombia-Santander,province,Colombia,Santander,NA,NA,NA,NA,
+Colombia-C?doba,province,Colombia,C?doba,NA,NA,NA,NA,
+Colombia-Meta,province,Colombia,Meta,NA,NA,NA,NA,
+Colombia-Tolima,province,Colombia,Tolima,NA,NA,NA,NA,
+Colombia-Atl?tico,province,Colombia,Atl?tico,NA,NA,NA,NA,
+Colombia-Cesar,province,Colombia,Cesar,NA,NA,NA,NA,
+Colombia-Antioquia,province,Colombia,Antioquia,NA,NA,NA,NA,
+Colombia-Casanare,province,Colombia,Casanare,NA,NA,NA,NA,
+Colombia-Santa_Marta,province,Colombia,SantaMarta,NA,NA,NA,NA,
+Colombia-Sucre,province,Colombia,Sucre,NA,NA,NA,NA,
+Colombia-Magdalena,province,Colombia,Magdalena,NA,NA,NA,NA,
+Colombia-Bogot?province,Colombia,Bogot?NA,NA,NA,NA,
+Colombia-Caquet?province,Colombia,Caquet?NA,NA,NA,NA,
+Colombia-Cundinamarca,province,Colombia,Cundinamarca,NA,NA,NA,NA,
+Colombia-Arauca,province,Colombia,Arauca,NA,NA,NA,NA,
+Colombia-Guajira,province,Colombia,Guajira,NA,NA,NA,NA,
+Colombia-Risaralda,province,Colombia,Risaralda,NA,NA,NA,NA,
+Colombia-Bol?ar,province,Colombia,Bol?ar,NA,NA,NA,NA,
+Colombia-Putumayo,province,Colombia,Putumayo,NA,NA,NA,NA,
+Colombia-Cartagena,province,Colombia,Cartagena,NA,NA,NA,NA,
+Colombia-Cauca,province,Colombia,Cauca,NA,NA,NA,NA,
+Colombia-Quind?,province,Colombia,Quind?,NA,NA,NA,NA,
+Colombia-Caldas,province,Colombia,Caldas,NA,NA,NA,NA,
+Colombia-Amazonas,province,Colombia,Amazonas,NA,NA,NA,NA,
+Colombia-Boyac?province,Colombia,Boyac?NA,NA,NA,NA,
+Colombia-San_Andr?,province,Colombia,SanAndr?,NA,NA,NA,NA,
+Colombia-Buenaventura,province,Colombia,Buenaventura,NA,NA,NA,NA,
+Colombia-Nari?,province,Colombia,Nari?,NA,NA,NA,NA,
+Colombia-Guaviare,province,Colombia,Guaviare,NA,NA,NA,NA,
+Colombia-Vichada,province,Colombia,Vichada,NA,NA,NA,NA,
+Colombia-Choco,province,Colombia,Choco,NA,NA,NA,NA,
+Colombia-Vaup?,province,Colombia,Vaup?,NA,NA,NA,NA,
+Colombia-Guain?,province,Colombia,Guain?,NA,NA,NA,NA,
+Colombia-Exterior,province,Colombia,Exterior,NA,NA,NA,NA,


### PR DESCRIPTION
Locations throughout the datasets in this repository are missing a canonical id and instead are identified by there textual names.  This makes it very difficult to join with other data sets in that it can be difficult to match names due to differences in spelling, accents, capitalization, etc.

This pull request adds the canonical numerical IDs for Colombian municipalities as provided in the original municipality documents, such as [this](https://github.com/ml9951/zika/blob/master/Colombia/Municipality_Zika/original_reports/CONTEO%20CASOS%20ZIKA%20MUNICIPIOS%20SE%2042%202016.pdf) one.  This allows for easier cross referencing with other datasets at the Colombian municipality level.  Other datasets that I am using for Colombia use these same IDs, such as [this one](https://github.com/luiscape/colombia_population) and [this one](https://github.com/santiblanko/colombia.geojson)