### PR TITLE
Removing star from COES_Microcephaly-2016-06-04.csv

### DIFF
--- a/Brazil/COES_Microcephaly/data/COES_Microcephaly-2016-06-04.csv
+++ b/Brazil/COES_Microcephaly/data/COES_Microcephaly-2016-06-04.csv
@@ -174,7 +174,7 @@
 "2016-06-04","Brazil-Paraiba","state","microcephaly_fatal_not","BR0007",NA,NA,"3","cases"
 "2016-06-04","Brazil-Parana","state","microcephaly_fatal_not","BR0007",NA,NA,"2","cases"
 "2016-06-04","Brazil-Pernambuco","state","microcephaly_fatal_not","BR0007",NA,NA,"2","cases"
-"2016-06-04","Brazil-Piaui","state","microcephaly_fatal_not","BR0007",NA,NA,"5*","cases"
+"2016-06-04","Brazil-Piaui","state","microcephaly_fatal_not","BR0007",NA,NA,"5","cases"
 "2016-06-04","Brazil-Rio_Grande_do_Norte","state","microcephaly_fatal_not","BR0007",NA,NA,"0","cases"
 "2016-06-04","Brazil-Rio_Grande_do_Sul","state","microcephaly_fatal_not","BR0007",NA,NA,"7","cases"
 "2016-06-04","Brazil-Rio_de_Janeiro","state","microcephaly_fatal_not","BR0007",NA,NA,"5","cases"


### PR DESCRIPTION
There is an extraneous star in `Brazil/COES_Microcephaly/data/COES_Microcephaly-2016-06-04.csv`.  Below is a screen shot of where it came from in the original document.

![Imgur](http://i.imgur.com/sk2yPlg.png)

It might be good to somehow encode this sidenote in the data, but a star without any other information in the table doesn't seem like the right way.  