### PR TITLE
Fix validation errors

### DIFF
--- a/Guatemala/SEMEPI/data/SEMEPI_14_2017.csv
+++ b/Guatemala/SEMEPI/data/SEMEPI_14_2017.csv
@@ -1,7 +1,6 @@
 report_date,location,location_type,data_field,data_field_code,time_period,time_period_type,value,unit
 2017-04-09,Guatemala-Escuintla,municipality,total_zika_suspected,GT0001,NA,NA,1215.0,cases
 2017-04-09,Guatemala,country,total_zika_suspected,GT0001,NA,NA,,cases
-2017-04-09,Guatemala-Escuintla,municipality,total_zika_suspected,GT0001,NA,NA,1215.0,cases
 2017-04-09,Guatemala-Izabal,municipality,total_zika_suspected,GT0001,NA,NA,61.0,cases
 2017-04-09,Guatemala-Suchitepequez,municipality,total_zika_suspected,GT0001,NA,NA,59.0,cases
 2017-04-09,Guatemala-Peten_Norte,municipality,total_zika_suspected,GT0001,NA,NA,19.0,cases

--- a/Guatemala/SEMEPI/data/SEMEPI_20_2017.csv
+++ b/Guatemala/SEMEPI/data/SEMEPI_20_2017.csv
@@ -1,5 +1,4 @@
 report_date,location,location_type,data_field,data_field_code,time_period,time_period_type,value,unit
-2017-05-21,Guatemala-Retalhuleu,municipality,total_zika_suspected,GT0001,NA,NA,,cases
 2017-05-21,Guatemala-Central,municipality,total_zika_suspected,GT0001,NA,NA,101.0,cases
 2017-05-21,Guatemala-Santa_Rosa,municipality,total_zika_suspected,GT0001,NA,NA,20.0,cases
 2017-05-21,Guatemala-Escuintla,municipality,total_zika_suspected,GT0001,NA,NA,23.0,cases

--- a/Puerto_Rico/PRDH_Arbovirus/data/PRDH_Zika_2016-05-19.csv
+++ b/Puerto_Rico/PRDH_Arbovirus/data/PRDH_Zika_2016-05-19.csv
@@ -9,6 +9,6 @@
 "2016-05-19","United_States-Puerto_Rico","territory","gbs_reported_cumulative_2015-2016","PR0010",NA,NA,7,"cases"
 "2016-05-19","United_States-Puerto_Rico","territory","gbs_reported_zika_confirmed","PR0013",NA,NA,5,"cases"
 "2016-05-19","United_States-Puerto_Rico","territory","gbs_reported_flavi_confirmed","PR0014",NA,NA,2,"cases"
-"2016-05-19","United_States-Puerto_Rico","territory","congenital_developmental_defects_reported_cumulative_2015-2016","PR0015",NA,NA,1,"cases"
+"2016-05-19","United_States-Puerto_Rico","territory","congenital_developmental_defects_reported_cummulative_2015-2016","PR0015",NA,NA,1,"cases"
 "2016-05-19","United_States-Puerto_Rico","territory","arbovirus_suspected_4weeks","PR0011",NA,NA,2079,"cases"
 "2016-05-19","United_States-Puerto_Rico","territory","arbovirus_suspected_cumulative_2016","PR0012",NA,NA,7337,"cases"

--- a/Puerto_Rico/PRDH_Arbovirus/data/PRDH_Zika_2017-07-07.csv
+++ b/Puerto_Rico/PRDH_Arbovirus/data/PRDH_Zika_2017-07-07.csv
@@ -1,4 +1,4 @@
-location,location_type,data_field,data_field_code,time_period,time_period_type,value,unit,
+report_date,location,location_type,data_field,data_field_code,time_period,time_period_type,value,unit,
 2017-07-07,United_States-Puerto_Rico,territory,zika_confirmed_4weeks,PR0001,NA,NA,6,cases
 2017-07-07,United_States-Puerto_Rico,territory,zika_confirmed_cumulative_2016,PR0003,NA,NA,39039,cases
 2017-07-07,United_States-Puerto_Rico,territory,flavi_confirmed_cumulative_2016,PR0005,NA,NA,592,cases

--- a/Puerto_Rico/PRDH_Arbovirus/data/PRDH_Zika_2017-07-14.csv
+++ b/Puerto_Rico/PRDH_Arbovirus/data/PRDH_Zika_2017-07-14.csv
@@ -1,4 +1,4 @@
-location,location_type,data_field,data_field_code,time_period,time_period_type,value,unit,,
+report_date,location,location_type,data_field,data_field_code,time_period,time_period_type,value,unit,,
 2017-07-14,United_States-Puerto_Rico,territory,zika_confirmed_4weeks,PR0001,NA,NA,2,cases,
 2017-07-14,United_States-Puerto_Rico,territory,zika_confirmed_cumulative_2016,PR0003,NA,NA,39041,cases,
 2017-07-14,United_States-Puerto_Rico,territory,flavi_confirmed_cumulative_2016,PR0005,NA,NA,592,cases,

--- a/Puerto_Rico/PRDH_Arbovirus/data/PRDH_Zika_2017-07-21.csv
+++ b/Puerto_Rico/PRDH_Arbovirus/data/PRDH_Zika_2017-07-21.csv
@@ -1,4 +1,4 @@
-location,location_type,data_field,data_field_code,time_period,time_period_type,value,unit,,
+report_date,location,location_type,data_field,data_field_code,time_period,time_period_type,value,unit,,
 2017-07-21,United_States-Puerto_Rico,territory,zika_confirmed_4weeks,PR0001,NA,NA,3,cases,
 2017-07-21,United_States-Puerto_Rico,territory,zika_confirmed_cumulative_2016,PR0003,NA,NA,39041,cases,
 2017-07-21,United_States-Puerto_Rico,territory,flavi_confirmed_cumulative_2016,PR0005,NA,NA,592,cases,

--- a/Puerto_Rico/PRDH_Arbovirus/data/PRDH_Zika_2017-07-28.csv
+++ b/Puerto_Rico/PRDH_Arbovirus/data/PRDH_Zika_2017-07-28.csv
@@ -1,4 +1,4 @@
-location,location_type,data_field,data_field_code,time_period,time_period_type,value,unit,
+report_date,location,location_type,data_field,data_field_code,time_period,time_period_type,value,unit,
 2017-07-28,United_States-Puerto_Rico,territory,zika_confirmed_4weeks,PR0001,NA,NA,2,cases
 2017-07-28,United_States-Puerto_Rico,territory,zika_confirmed_cumulative_2016,PR0003,NA,NA,39043,cases
 2017-07-28,United_States-Puerto_Rico,territory,flavi_confirmed_cumulative_2016,PR0005,NA,NA,592,cases

--- a/Puerto_Rico/PRDH_Arbovirus/data/PRDH_Zika_2017-08-04.csv
+++ b/Puerto_Rico/PRDH_Arbovirus/data/PRDH_Zika_2017-08-04.csv
@@ -1,4 +1,4 @@
-location,location_type,data_field,data_field_code,time_period,time_period_type,value,unit,
+report_date,location,location_type,data_field,data_field_code,time_period,time_period_type,value,unit,
 2017-08-04,United_States-Puerto_Rico,territory,zika_confirmed_4weeks,PR0001,NA,NA,3,cases
 2017-08-04,United_States-Puerto_Rico,territory,zika_confirmed_cumulative_2016,PR0003,NA,NA,39059,cases
 2017-08-04,United_States-Puerto_Rico,territory,flavi_confirmed_cumulative_2016,PR0005,NA,NA,592,cases


### PR DESCRIPTION
This PR removes two duplicate rows (Guatemala), fixes a typo (`Puerto_Rico/PRDH_Arbovirus/data/PRDH_Zika_2016-05-19.csv`) and adds missing columns to a few of the Puerto Rico files.  This doesn't fix all of the validation errors, but I am able to successfully validate all the files for Argentina, Haiti, United_States, Brazil, Mexico, Puerto_Rico, France, USVI.  More fixes to come.