### PR TITLE
Removing duplicate row from CO_Places.csv

### DIFF
--- a/Colombia/CO_Places.csv
+++ b/Colombia/CO_Places.csv
@@ -1207,7 +1207,6 @@ Colombia-Cundinamarca,province,Colombia,Cundinamarca,NA,NA,NA,NA
 Colombia-Arauca,province,Colombia,Arauca,NA,NA,NA,NA
 Colombia-Guajira,province,Colombia,Guajira,NA,NA,NA,NA
 Colombia-Risaralda,province,Colombia,Risaralda,NA,NA,NA,NA
-Colombia-Bolivar,province,Colombia,Bolivar,NA,NA,NA,NA
 Colombia-Putumayo,province,Colombia,Putumayo,NA,NA,NA,NA
 Colombia-Cartagena,province,Colombia,Cartagena,NA,NA,NA,NA
 Colombia-Cauca,province,Colombia,Cauca,NA,NA,NA,NA


### PR DESCRIPTION
This row already existed on line 1189 [[1](https://github.com/ml9951/zika/blob/dc7352a2407b95583ed060c29977cedf04d19c5f/Colombia/CO_Places.csv#L1189)]